### PR TITLE
Fix GDI+ test, Add MagicScaler test

### DIFF
--- a/CoreCompat/LoadResizeSave.cs
+++ b/CoreCompat/LoadResizeSave.cs
@@ -74,7 +74,7 @@ namespace ImageProcessing
 
         void SystemDrawingResize(string path, int size, string outputDirectory)
         {
-            using (var image = new Bitmap(SystemDrawingImage.FromFile(path)))
+            using (var image = SystemDrawingImage.FromFile(path, true))
             {
                 int width, height;
                 if (image.Width > image.Height)
@@ -89,11 +89,14 @@ namespace ImageProcessing
                 }
                 var resized = new Bitmap(width, height);
                 using (var graphics = Graphics.FromImage(resized))
+                using (var attributes = new ImageAttributes())
                 {
+                    attributes.SetWrapMode(WrapMode.TileFlipXY);
+                    graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
                     graphics.CompositingQuality = CompositingQuality.HighSpeed;
                     graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
                     graphics.CompositingMode = CompositingMode.SourceCopy;
-                    graphics.DrawImage(image, 0, 0, width, height);
+                    graphics.DrawImage(image, Rectangle.FromLTRB(0, 0, width, height), 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attributes);
                     // Save the results
                     using (var output = File.Open(OutputPath(path, outputDirectory, SystemDrawing), FileMode.Create))
                     {

--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -4,6 +4,7 @@ using ImageSharp.Formats;
 using ImageSharp.Processing;
 using ImageMagick;
 using FreeImageAPI;
+using PhotoSauce.MagicScaler;
 
 using System.Collections.Generic;
 using System.IO;
@@ -22,6 +23,7 @@ namespace ImageProcessing
         const string SystemDrawing = nameof(SystemDrawing);
         const string MagickNET = nameof(MagickNET);
         const string FreeImage = nameof(FreeImage);
+        const string MagicScaler = nameof(MagicScaler);
 
         readonly IEnumerable<string> _images;
         readonly string _outputDirectory;
@@ -154,6 +156,32 @@ namespace ImageProcessing
                resized.Save(OutputPath(path, outputDirectory, FreeImage), FREE_IMAGE_FORMAT.FIF_JPEG,
                    FREE_IMAGE_SAVE_FLAGS.JPEG_QUALITYGOOD |
                    FREE_IMAGE_SAVE_FLAGS.JPEG_BASELINE);
+            }
+        }
+
+        [Benchmark(Description = "MagicScaler Load, Resize, Save")]
+        public void MagicScalerResizeBenchmark()
+        {
+            foreach (var image in _images)
+            {
+                MagicScalerResize(image, ThumbnailSize, _outputDirectory);
+            }
+        }
+
+        static void MagicScalerResize(string path, int size, string outputDirectory)
+        {
+            var settings = new ProcessImageSettings() {
+                Width = size,
+                Height = size,
+                ResizeMode = CropScaleMode.Max,
+                SaveFormat = FileFormat.Jpeg,
+                JpegQuality = Quality,
+                JpegSubsampleMode = ChromaSubsampleMode.Subsample420
+            };
+
+            using (var output = new FileStream(OutputPath(path, outputDirectory, MagicScaler), FileMode.Create))
+            {
+                MagicImageProcessor.ProcessImage(path, output, settings);
             }
         }
     }

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -13,6 +13,7 @@ namespace ImageProcessing
             //lrs.ImageSharpBenchmark();
             //lrs.MagickResizeBenchmark();
             //lrs.FreeImageResizeBenchmark();
+            //lrs.MagicScalerResizeBenchmark();
             new BenchmarkSwitcher(typeof(Program).GetTypeInfo().Assembly).Run(args);
         }
     }

--- a/NetCore/project.json
+++ b/NetCore/project.json
@@ -5,18 +5,19 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.3"
+          "version": "1.1.0"
         },
-        "BenchmarkDotNet": "0.10.0",
+        "BenchmarkDotNet": "0.10.2",
         "ImageSharp": "1.0.0-alpha1-00054",
         "ImageSharp.Formats.Jpeg": "1.0.0-alpha1-00034",
         "ImageSharp.Processing": "1.0.0-alpha1-00034",
         "Magick.NET.Core-Q8": "7.0.4.400",
-        "FreeImage-dotnet-core": "4.0.0"
+        "FreeImage-dotnet-core": "4.0.0",
+        "PhotoSauce.MagicScaler": "0.7.0-alpha"
       },
       "imports": "dnxcore50"
     }


### PR DESCRIPTION
Added MagicScaler the the CoreNet benchmarks.  I had trouble with BenchmarkDotNet after adding my package, but the standalone call to the test method worked fine.  I was only able to get the full benchmarks to run by updating BenchmarkDotnet to the latest version, which required updating to .NET Core 1.1.

I don't know if updating beyond 1.0.3 is acceptable under the setup of your test, but since it appeared to be a problem with the BenchmarkDotNet and not with MagicScaler, I hope it's ok.

MagicScaler is built on WIC, so it only works on Windows for now.  I've been slowly replacing some of the WIC components to improve performance and image quality, and I plan to continue doing that until I have pure managed replacements for all the WIC components I use.  At that point, this library should work cross-platform.  I'll be working with James Jackson-South to see if we can develop a high-performance JPEG decoder/encoder to start with.