### PR TITLE
Add parallel versions of Load->Resize->Save tests

### DIFF
--- a/CoreCompat/LoadResizeSave.cs
+++ b/CoreCompat/LoadResizeSave.cs
@@ -16,23 +16,24 @@ namespace ImageProcessing
     {
         const int ThumbnailSize = 150;
         const int Quality = 75;
-        const string ImageSharp = nameof(ImageSharp);
         const string SystemDrawing = nameof(SystemDrawing);
-        const string MagickNET = nameof(MagickNET);
 
         readonly IEnumerable<string> _images;
         readonly string _outputDirectory;
-        readonly ImageCodecInfo _codec;
-        readonly EncoderParameters _encoderParameters;
+        static readonly ImageCodecInfo _codec;
+        static readonly EncoderParameters _encoderParameters;
 
-        public LoadResizeSave()
+        static LoadResizeSave()
         {
             // Initialize the encoder and parameters for System.Drawing
             var qualityParamId = Encoder.Quality;
             _encoderParameters = new EncoderParameters(1);
             _encoderParameters.Param[0] = new EncoderParameter(qualityParamId, Quality);
             _codec = ImageCodecInfo.GetImageDecoders().FirstOrDefault(codec => codec.FormatID == ImageFormat.Jpeg.Guid);
+        }
 
+        public LoadResizeSave()
+        {
             // Find the closest images directory
             var imageDirectory = Path.GetFullPath(".");
             while (!Directory.Exists(Path.Combine(imageDirectory, "images")))
@@ -72,7 +73,7 @@ namespace ImageProcessing
             }
         }
 
-        void SystemDrawingResize(string path, int size, string outputDirectory)
+        internal static void SystemDrawingResize(string path, int size, string outputDirectory)
         {
             using (var image = SystemDrawingImage.FromFile(path, true))
             {

--- a/CoreCompat/LoadResizeSaveParallel.cs
+++ b/CoreCompat/LoadResizeSaveParallel.cs
@@ -1,0 +1,48 @@
+﻿using BenchmarkDotNet.Attributes;
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ImageProcessing
+{
+    public class LoadResizeSaveParallel
+    {
+        const int ThumbnailSize = 150;
+
+        readonly IEnumerable<string> _images;
+        readonly string _outputDirectory;
+
+        public LoadResizeSaveParallel()
+        {
+            // Find the closest images directory
+            var imageDirectory = Path.GetFullPath(".");
+            while (!Directory.Exists(Path.Combine(imageDirectory, "images")))
+            {
+                imageDirectory = Path.GetDirectoryName(imageDirectory);
+                if (imageDirectory == null)
+                {
+                    throw new FileNotFoundException("Could not find an image directory.");
+                }
+            }
+            imageDirectory = Path.Combine(imageDirectory, "images");
+            // Get at most 20 images from there
+            _images = Directory.EnumerateFiles(imageDirectory).Take(20);
+            // Create the output directory next to the images directory
+            _outputDirectory = Path.Combine(Path.GetDirectoryName(imageDirectory), "output");
+            if (!Directory.Exists(_outputDirectory))
+            {
+                Directory.CreateDirectory(_outputDirectory);
+            }
+        }
+
+        [Benchmark(Baseline = true, Description = "System.Drawing Load, Resize, Save - Parallel")]
+        public void SystemDrawingResizeBenchmark()
+        {
+            Parallel.ForEach(_images, image => {
+                LoadResizeSave.SystemDrawingResize(image, ThumbnailSize, _outputDirectory);
+            });
+        }
+    }
+}

--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -28,12 +28,15 @@ namespace ImageProcessing
         readonly IEnumerable<string> _images;
         readonly string _outputDirectory;
 
-        public LoadResizeSave()
+        static LoadResizeSave()
         {
             OpenCL.IsEnabled = false;
             // Add ImageSharp Formats
             Configuration.Default.AddImageFormat(new JpegFormat());
+        }
 
+        public LoadResizeSave()
+        {
             // Find the closest images directory
             var imageDirectory = Path.GetFullPath(".");
             while (!Directory.Exists(Path.Combine(imageDirectory, "images")))
@@ -73,7 +76,7 @@ namespace ImageProcessing
             }
         }
 
-        static void ImageSharpResize(string path, int size, string outputDirectory)
+        internal static void ImageSharpResize(string path, int size, string outputDirectory)
         {
             using (var input = File.OpenRead(path))
             {
@@ -108,7 +111,7 @@ namespace ImageProcessing
             }
         }
 
-        static void MagickResize(string path, int size, string outputDirectory)
+        internal static void MagickResize(string path, int size, string outputDirectory)
         {
             using (var image = new MagickImage(path))
             {
@@ -135,7 +138,7 @@ namespace ImageProcessing
             }
         }
 
-        static void FreeImageResize(string path, int size, string outputDirectory)
+        internal static void FreeImageResize(string path, int size, string outputDirectory)
         {
             using (var original = FreeImageBitmap.FromFile(path))
             {
@@ -168,7 +171,7 @@ namespace ImageProcessing
             }
         }
 
-        static void MagicScalerResize(string path, int size, string outputDirectory)
+        internal static void MagicScalerResize(string path, int size, string outputDirectory)
         {
             var settings = new ProcessImageSettings() {
                 Width = size,

--- a/NetCore/LoadResizeSaveParallel.cs
+++ b/NetCore/LoadResizeSaveParallel.cs
@@ -1,0 +1,72 @@
+﻿using BenchmarkDotNet.Attributes;
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ImageProcessing
+{
+    public class LoadResizeSaveParallel
+    {
+        const int ThumbnailSize = 150;
+
+        readonly IEnumerable<string> _images;
+        readonly string _outputDirectory;
+
+        public LoadResizeSaveParallel()
+        {
+            // Find the closest images directory
+            var imageDirectory = Path.GetFullPath(".");
+            while (!Directory.Exists(Path.Combine(imageDirectory, "images")))
+            {
+                imageDirectory = Path.GetDirectoryName(imageDirectory);
+                if (imageDirectory == null)
+                {
+                    throw new FileNotFoundException("Could not find an image directory.");
+                }
+            }
+            imageDirectory = Path.Combine(imageDirectory, "images");
+            // Get at most 20 images from there
+            _images = Directory.EnumerateFiles(imageDirectory).Take(20);
+            // Create the output directory next to the images directory
+            _outputDirectory = Path.Combine(Path.GetDirectoryName(imageDirectory), "output");
+            if (!Directory.Exists(_outputDirectory))
+            {
+                Directory.CreateDirectory(_outputDirectory);
+            }
+        }
+
+        [Benchmark(Description = "ImageSharp Load, Resize, Save - Parallel")]
+        public void ImageSharpBenchmark()
+        {
+            Parallel.ForEach(_images, image => {
+                LoadResizeSave.ImageSharpResize(image, ThumbnailSize, _outputDirectory);
+            });
+        }
+
+        [Benchmark(Description = "ImageMagick Load, Resize, Save - Parallel")]
+        public void MagickResizeBenchmark()
+        {
+            Parallel.ForEach(_images, image => {
+                LoadResizeSave.MagickResize(image, ThumbnailSize, _outputDirectory);
+            });
+        }
+
+        [Benchmark(Description = "ImageFree Load, Resize, Save - Parallel")]
+        public void FreeImageResizeBenchmark()
+        {
+            Parallel.ForEach(_images, image => {
+                LoadResizeSave.FreeImageResize(image, ThumbnailSize, _outputDirectory);
+            });
+        }
+
+        [Benchmark(Description = "MagicScaler Load, Resize, Save - Parallel")]
+        public void MagicScalerResizeBenchmark()
+        {
+            Parallel.ForEach(_images, image => {
+                LoadResizeSave.MagicScalerResize(image, ThumbnailSize, _outputDirectory);
+            });
+        }
+    }
+}


### PR DESCRIPTION
I don't know if this is of interest to you, but I added benchmarks that run the existting Load->Resize->Save tests using TPL to highlight any potential scalability issues in the imaging libraries.  The only two that don't scale up more or less linearly are CoreCompat (as you pointed out in your post) and ImageSharp (which spins up its own extra threads internally).  I didn't update the Skia one since I can't run it.

