### PR TITLE
Update ImageSharp and Magic.NET dependencies

### DIFF
--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -83,21 +83,23 @@ namespace ImageProcessing
                 using (var output = File.Open(OutputPath(path, outputDirectory, ImageSharp), FileMode.Create))
                 {
                     // Resize it to fit a 150x150 square
-                    var image = new ImageSharpImage(input)
-                        .Resize(new ResizeOptions
+                    using (var image = new ImageSharpImage(input))
+                    {
+                        image.Resize(new ResizeOptions
                         {
                             Size = new ImageSharpSize(size, size),
                             Mode = ResizeMode.Max
                         });
 
-                    // Reduce the size of the file
-                    image.ExifProfile = null;
+                        // Reduce the size of the file
+                        image.ExifProfile = null;
 
-                    // Set the quality
-                    image.Quality = Quality;
+                        // Set the quality
+                        image.Quality = Quality;
 
-                    // Save the results
-                    image.Save(output);
+                        // Save the results
+                        image.Save(output);
+                    }
                 }
             }
         }

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -27,8 +27,10 @@ namespace ImageProcessing
         [Benchmark(Description = "ImageSharp Resize")]
         public ImageSharpSize ResizeImageSharp()
         {
-            ImageSharpImage image = new ImageSharpImage(Width, Height);
-            image.Resize(ResizedWidth, ResizedHeight);
+            using (ImageSharpImage image = new ImageSharpImage(Width, Height))
+            {
+                image.Resize(ResizedWidth, ResizedHeight);
+            }
             return new ImageSharpSize(ResizedWidth, ResizedHeight);
         }
 

--- a/NetCore/project.json
+++ b/NetCore/project.json
@@ -12,10 +12,10 @@
           "version": "1.1.0"
         },
         "BenchmarkDotNet": "0.10.2",
-        "ImageSharp": "1.0.0-alpha1-00054",
-        "ImageSharp.Formats.Jpeg": "1.0.0-alpha1-00034",
-        "ImageSharp.Processing": "1.0.0-alpha1-00034",
-        "Magick.NET.Core-Q8": "7.0.4.400",
+        "ImageSharp": "1.0.0-alpha2-00042",
+        "ImageSharp.Formats.Jpeg": "1.0.0-alpha2-00042",
+        "ImageSharp.Processing": "1.0.0-alpha2-00030",
+        "Magick.NET.Core-Q8": "7.0.4.700",
         "FreeImage-dotnet-core": "4.0.0",
         "PhotoSauce.MagicScaler": "0.7.0-alpha"
       },


### PR DESCRIPTION
This updates the ImageSharp and Magick.NET dependencies to the latest releases. 

The ImageSharp benchmarks results should be faster and use less memory now that we are pooling internally. Unfortunately I am unable to get them to run as I have a side-by-side install of VS2015 and VS2017. The project builds once I add a global.js but when I go to run the benchmarks I get the following error.

>Unable to resolve 'NetCore (>= 1.0.0)' for '.NETCoreApp,Version=v1.1'.

Uninstalling VS2017 will fix this but I don't want to do that of course. It's beyond me how to make it work.

