### PR TITLE
Update libraries and add more test parity

### DIFF
--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -207,7 +207,7 @@ namespace ImageProcessing
             }
         }
 
-        static void SkiaCanvasLoadResizeSave(string path, int size, string outputDirectory)
+        internal static void SkiaCanvasLoadResizeSave(string path, int size, string outputDirectory)
         {
             using (var input = File.OpenRead(path))
             {
@@ -245,7 +245,7 @@ namespace ImageProcessing
             }
         }
 
-        static void SkiaBitmapLoadResizeSave(string path, int size, string outputDirectory)
+        internal static void SkiaBitmapLoadResizeSave(string path, int size, string outputDirectory)
         {
             using (var input = File.OpenRead(path))
             {

--- a/NetCore/LoadResizeSaveParallel.cs
+++ b/NetCore/LoadResizeSaveParallel.cs
@@ -68,5 +68,21 @@ namespace ImageProcessing
                 LoadResizeSave.MagicScalerResize(image, ThumbnailSize, _outputDirectory);
             });
         }
+
+        [Benchmark(Description = "SkiaSharp Canvas Load, Resize, Save - Parallel")]
+        public void SkiaCanvasResizeBenchmark()
+        {
+            Parallel.ForEach(_images, image => {
+                LoadResizeSave.SkiaCanvasLoadResizeSave(image, ThumbnailSize, _outputDirectory);
+            });
+        }
+
+        [Benchmark(Description = "SkiaSharp Bitmap Load, Resize, Save - Parallel")]
+        public void SkiaBitmapResizeBenchmark()
+        {
+            Parallel.ForEach(_images, image => {
+                LoadResizeSave.SkiaBitmapLoadResizeSave(image, ThumbnailSize, _outputDirectory);
+            });
+        }
     }
 }

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.3" />
-    <PackageReference Include="ImageSharp" Version="1.0.0-alpha6-00065" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.6" />
+    <PackageReference Include="ImageSharp" Version="1.0.0-alpha9-00034" />
     <PackageReference Include="Magick.NET.Core-Q8" Version="7.0.5.502" />
-    <PackageReference Include="FreeImage-dotnet-core" Version="4.0.0" />
-    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.7.0-alpha" />
-    <PackageReference Include="SkiaSharp" Version="1.57.0" />
+    <PackageReference Include="FreeImage-dotnet-core" Version="4.0.3" />
+    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.8.0-alpha1" />
+    <PackageReference Include="SkiaSharp" Version="1.57.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -35,6 +35,8 @@ namespace ImageProcessing
                     lrs.MagickResizeBenchmark();
                     lrs.FreeImageResizeBenchmark();
                     lrs.MagicScalerResizeBenchmark();
+                    lrs.SkiaBitmapLoadResizeSaveBenchmark();
+                    lrs.SkiaCanvasLoadResizeSaveBenchmark();
                     break;
                 case ConsoleKey.D1:
                     BenchmarkRunner.Run<Resize>(config);


### PR DESCRIPTION
Added MagicScaler resize-only test and added Skia tests to the parallel and single-run options.

I also created a shared function for calculating output size for the libraries that don't do it themselves.  The output sizes are more consistent between the tests now.
