### PR TITLE
Add NetVips to NetCore benchmarks

### DIFF
--- a/NetCore/LoadResizeSaveParallel.cs
+++ b/NetCore/LoadResizeSaveParallel.cs
@@ -1,104 +1,64 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace ImageProcessing
 {
-    public class LoadResizeSaveParallel
+    public class LoadResizeSaveParallel : LoadResizeSave
     {
-        private const int ThumbnailSize = 150;
-        private readonly IEnumerable<string> images;
-        private readonly string outputDirectory;
-
-        public LoadResizeSaveParallel()
+        [Benchmark(Baseline = true, Description = "System.Drawing Load, Resize, Save - Parallel"/*,
+            OperationsPerInvoke = ImagesCount*/)]
+        public void SystemDrawingBenchmarkParallel()
         {
-            // Find the closest images directory
-            string imageDirectory = Path.GetFullPath(".");
-            while (!Directory.Exists(Path.Combine(imageDirectory, "images")))
-            {
-                imageDirectory = Path.GetDirectoryName(imageDirectory);
-                if (imageDirectory == null)
-                {
-                    throw new FileNotFoundException("Could not find an image directory.");
-                }
-            }
-
-            imageDirectory = Path.Combine(imageDirectory, "images");
-
-            // Get at most 20 images from there
-            this.images = Directory.EnumerateFiles(imageDirectory).Take(20);
-
-            // Create the output directory next to the images directory
-            this.outputDirectory = Path.Combine(Path.GetDirectoryName(imageDirectory), "output");
-            if (!Directory.Exists(this.outputDirectory))
-            {
-                Directory.CreateDirectory(this.outputDirectory);
-            }
+            Parallel.ForEach(Images, SystemDrawingResize);
         }
 
-        [Benchmark(Baseline = true, Description = "System.Drawing Load, Resize, Save - Parallel")]
-        public void SystemDrawingResizeBenchmark()
+        [Benchmark(Description = "ImageSharp Load, Resize, Save - Parallel"/*,
+            OperationsPerInvoke = ImagesCount*/)]
+        public void ImageSharpBenchmarkParallel()
         {
-            Parallel.ForEach(this.images, image =>
-            {
-                LoadResizeSave.SystemDrawingResize(image, ThumbnailSize, this.outputDirectory);
-            });
+            Parallel.ForEach(Images, ImageSharpResize);
         }
 
-        [Benchmark(Description = "ImageSharp Load, Resize, Save - Parallel")]
-        public void ImageSharpResizeBenchmark()
+        [Benchmark(Description = "ImageMagick Load, Resize, Save - Parallel"/*,
+            OperationsPerInvoke = ImagesCount*/)]
+        public void MagickBenchmarkParallel()
         {
-            Parallel.ForEach(this.images, image =>
-            {
-                LoadResizeSave.ImageSharpResize(image, ThumbnailSize, this.outputDirectory);
-            });
+            Parallel.ForEach(Images, MagickResize);
         }
 
-        [Benchmark(Description = "ImageMagick Load, Resize, Save - Parallel")]
-        public void MagickResizeBenchmark()
+        [Benchmark(Description = "ImageFree Load, Resize, Save - Parallel"/*,
+            OperationsPerInvoke = ImagesCount*/)]
+        public void FreeImageBenchmarkParallel()
         {
-            Parallel.ForEach(this.images, image =>
-            {
-                LoadResizeSave.MagickResize(image, ThumbnailSize, this.outputDirectory);
-            });
+            Parallel.ForEach(Images, FreeImageResize);
         }
 
-        [Benchmark(Description = "ImageFree Load, Resize, Save - Parallel")]
-        public void FreeImageResizeBenchmark()
+        [Benchmark(Description = "MagicScaler Load, Resize, Save - Parallel"/*,
+            OperationsPerInvoke = ImagesCount*/)]
+        public void MagicScalerBenchmarkParallel()
         {
-            Parallel.ForEach(this.images, image =>
-            {
-                LoadResizeSave.FreeImageResize(image, ThumbnailSize, this.outputDirectory);
-            });
+            Parallel.ForEach(Images, MagickResize);
         }
 
-        [Benchmark(Description = "MagicScaler Load, Resize, Save - Parallel")]
-        public void MagicScalerResizeBenchmark()
+        [Benchmark(Description = "SkiaSharp Canvas Load, Resize, Save - Parallel"/*,
+            OperationsPerInvoke = ImagesCount*/)]
+        public void SkiaCanvasBenchmarkParallel()
         {
-            Parallel.ForEach(this.images, image =>
-            {
-                LoadResizeSave.MagicScalerResize(image, ThumbnailSize, this.outputDirectory);
-            });
+            Parallel.ForEach(Images, SkiaCanvasResize);
         }
 
-        [Benchmark(Description = "SkiaSharp Canvas Load, Resize, Save - Parallel")]
-        public void SkiaCanvasResizeBenchmark()
+        [Benchmark(Description = "SkiaSharp Bitmap Load, Resize, Save - Parallel"/*,
+            OperationsPerInvoke = ImagesCount*/)]
+        public void SkiaBitmapBenchmarkParallel()
         {
-            Parallel.ForEach(this.images, image =>
-            {
-                LoadResizeSave.SkiaCanvasLoadResizeSave(image, ThumbnailSize, this.outputDirectory);
-            });
+            Parallel.ForEach(Images, SkiaBitmapResize);
         }
 
-        [Benchmark(Description = "SkiaSharp Bitmap Load, Resize, Save - Parallel")]
-        public void SkiaBitmapResizeBenchmark()
+        [Benchmark(Description = "NetVips Load, Resize, Save - Parallel"/*,
+            OperationsPerInvoke = ImagesCount*/)]
+        public void NetVipsBenchmarkParallel()
         {
-            Parallel.ForEach(this.images, image =>
-            {
-                LoadResizeSave.SkiaBitmapLoadResizeSave(image, ThumbnailSize, this.outputDirectory);
-            });
+            Parallel.ForEach(Images, NetVipsResize);
         }
     }
 }

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -1,24 +1,33 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>NetCore</AssemblyName>
     <OutputType>Exe</OutputType>
+    <Optimize>true</Optimize>
     <PackageId>NetCore</PackageId>
+    <RootNamespace>ImageProcessing</RootNamespace>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <BenchmarkWithNuGetBinaries>true</BenchmarkWithNuGetBinaries>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Include="FreeImage.Standard" Version="4.3.7" />
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.12.0" />
+    <PackageReference Include="NetVips" Version="1.1.0-rc1" />
     <PackageReference Include="PhotoSauce.MagicScaler" Version="0.9.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-dev002604" />
     <PackageReference Include="SkiaSharp" Version="1.68.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BenchmarkWithNuGetBinaries)' == 'true'">
+    <PackageReference Include="NetVips.Native" Version="8.8.0-rc2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="1.68.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NetCore/NuGet.config
+++ b/NetCore/NuGet.config
@@ -1,7 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="ImageSharp Nightly" value="https://www.myget.org/F/sixlabors/api/v3/index.json" />
     <add key="Benchmark.NET Nightly" value="https://ci.appveyor.com/nuget/benchmarkdotnet" />
+    <add key="NetVips Nightly" value="https://ci.appveyor.com/nuget/net-vips" />
   </packageSources>
 </configuration>

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -5,6 +5,7 @@ using System.Drawing.Drawing2D;
 using BenchmarkDotNet.Attributes;
 using FreeImageAPI;
 using ImageMagick;
+using NetVips;
 using PhotoSauce.MagicScaler;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
@@ -126,6 +127,22 @@ namespace ImageProcessing
             {
                 return new SKSize(image.Width, image.Height);
             }
+        }
+
+        [Benchmark(Description = "NetVips Resize")]
+        public (int width, int height) NetVipsResize()
+        {
+            // Scaling calculations
+            const double xFactor = (double)Width / ResizedWidth;
+            const double yFactor = (double)Height / ResizedHeight;
+
+            // Make a black image
+            var image = NetVips.Image.Black(Width, Height);
+
+            // Resize
+            image = image.Reduce(xFactor, yFactor, kernel: Enums.Kernel.Linear);
+
+            return (image.Width, image.Height);
         }
     }
 }


### PR DESCRIPTION
This PR adds [NetVips](https://github.com/kleisauke/net-vips/), the C# binding for [libvips](https://libvips.github.io/libvips/) to the NetCore benchmarks. libvips is a lazy, streaming, demand-driven image processing library. 

On performance, there are quite a few vips benchmarks around. The main one is here: [Speed and memory use](https://github.com/libvips/libvips/wiki/Speed-and-memory-use). The C# binding isn't listed, but it should produce the same results as the Python one, so about 5 times faster than ImageMagick.

With the same test scenario I compared NetVips with other image libraries on .NET, the results can be viewed here: [NetVips.Benchmarks](https://github.com/kleisauke/net-vips/tree/master/tests/NetVips.Benchmarks). On this benchmark NetVips is around 14 times faster than Magick.NET and 5 times faster than ImageSharp. 

[Sharp](https://github.com/lovell/sharp), the popular image resizing package for Node.js, is also based on libvips. These benchmarks can be viewed here: [Performance - sharp](http://sharp.pixelplumbing.com/en/stable/performance/).

**Changes within this PR**
- Drop `internal static` functions, let `LoadResizeSaveParallel` inherit from `LoadResizeSave`.
- `OperationsPerInvoke` can be uncommented to get the average benchmark time per image.
- Prefer file input over stream based input.
- Remove superfluous parameters that don't change (`int size, string outputDirectory`).
- Exclude MagicScaler if not running on Windows.
   - MagicScaler requires Windows Imaging Component (WIC) which is only available on Windows.
- Remove BOM (Byte Order Mark) from UTF-8 files.
- Add `<Optimize>true</Optimize>` in the csproj file, see:
   https://benchmarkdotnet.org/articles/guides/good-practices.html
- Add `BenchmarkWithNuGetBinaries` property to enable/disable benchmarking with NuGet binaries. For example:
   ```bash
   dotnet build /p:BenchmarkWithNuGetBinaries=false
   ```

**NetCore benchmark results**
<details><summary>Benchmark results on Linux</summary>

``` ini

BenchmarkDotNet=v0.11.5, OS=fedora 30
Intel Core i5-8600K CPU 3.60GHz (Coffee Lake), 1 CPU, 6 logical and 6 physical cores
.NET Core SDK=2.2.203
  [Host]            : .NET Core 2.2.4 (CoreCLR 4.6.27521.02, CoreFX 4.6.27521.01), 64bit RyuJIT
  .Net Core 2.2 CLI : .NET Core 2.2.4 (CoreCLR 4.6.27521.02, CoreFX 4.6.27521.01), 64bit RyuJIT

Job=.Net Core 2.2 CLI  Toolchain=.NET Core 2.2  IterationCount=5  
LaunchCount=1  WarmupCount=5  

```
|                                Method |      Mean |      Error |    StdDev | Ratio | RatioSD |     Gen 0 | Gen 1 | Gen 2 |  Allocated |
|-------------------------------------- |----------:|-----------:|----------:|------:|--------:|----------:|------:|------:|-----------:|
|   &#39;System.Drawing Load, Resize, Save&#39; | 242.35 ms |  4.1197 ms | 1.0699 ms |  1.00 |    0.00 |         - |     - |     - |   10.13 KB |
|       &#39;ImageSharp Load, Resize, Save&#39; | 267.84 ms |  1.4081 ms | 0.3657 ms |  1.11 |    0.00 |         - |     - |     - | 1108.92 KB |
|      &#39;ImageMagick Load, Resize, Save&#39; | 347.99 ms |  3.0295 ms | 0.7868 ms |  1.44 |    0.01 |         - |     - |     - |   56.63 KB |
|        &#39;ImageFree Load, Resize, Save&#39; | 302.52 ms | 17.9630 ms | 4.6649 ms |  1.25 |    0.02 | 6000.0000 |     - |     - |   95.59 KB |
| &#39;SkiaSharp Canvas Load, Resize, Save&#39; | 130.79 ms |  0.5355 ms | 0.1391 ms |  0.54 |    0.00 |         - |     - |     - |  191.66 KB |
| &#39;SkiaSharp Bitmap Load, Resize, Save&#39; | 131.83 ms |  2.7465 ms | 0.7133 ms |  0.54 |    0.00 |         - |     - |     - |  187.58 KB |
|          &#39;NetVips Load, Resize, Save&#39; |  98.47 ms |  0.4220 ms | 0.1096 ms |  0.41 |    0.00 |        
</details>

On this benchmark that was performed on Linux, NetVips is about 2.5 times faster than Magick.NET and 1.7 times faster than ImageSharp.

<details><summary>Benchmark results on Windows</summary>

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17763.475 (1809/October2018Update/Redstone5)
Intel Core i5-8600K CPU 3.60GHz (Coffee Lake), 1 CPU, 6 logical and 6 physical cores
.NET Core SDK=2.2.203
  [Host]            : .NET Core 2.2.4 (CoreCLR 4.6.27521.02, CoreFX 4.6.27521.01), 64bit RyuJIT
  .Net Core 2.2 CLI : .NET Core 2.2.4 (CoreCLR 4.6.27521.02, CoreFX 4.6.27521.01), 64bit RyuJIT

Job=.Net Core 2.2 CLI  Toolchain=.NET Core 2.2  IterationCount=5  
LaunchCount=1  WarmupCount=5  

```
|                                Method |      Mean |      Error |    StdDev | Ratio | RatioSD |     Gen 0 | Gen 1 | Gen 2 |  Allocated |
|-------------------------------------- |----------:|-----------:|----------:|------:|--------:|----------:|------:|------:|-----------:|
|   &#39;System.Drawing Load, Resize, Save&#39; | 380.78 ms | 16.4810 ms | 4.2801 ms |  1.00 |    0.00 |         - |     - |     - |    10.3 KB |
|       &#39;ImageSharp Load, Resize, Save&#39; | 255.26 ms |  3.8147 ms | 0.9907 ms |  0.67 |    0.01 |         - |     - |     - | 1105.16 KB |
|      &#39;ImageMagick Load, Resize, Save&#39; | 399.98 ms | 10.1334 ms | 2.6316 ms |  1.05 |    0.02 |         - |     - |     - |   56.13 KB |
|        &#39;ImageFree Load, Resize, Save&#39; | 317.02 ms |  3.2722 ms | 0.8498 ms |  0.83 |    0.01 | 6000.0000 |     - |     - |   91.73 KB |
|      &#39;MagicScaler Load, Resize, Save&#39; |  88.12 ms |  0.8835 ms | 0.2294 ms |  0.23 |    0.00 |         - |     - |     - |  344.85 KB |
| &#39;SkiaSharp Canvas Load, Resize, Save&#39; | 189.30 ms |  2.3786 ms | 0.6177 ms |  0.50 |    0.01 |         - |     - |     - |   186.8 KB |
| &#39;SkiaSharp Bitmap Load, Resize, Save&#39; | 188.47 ms |  1.2058 ms | 0.3131 ms |  0.50 |    0.01 |         - |     - |     - |  183.67 KB |
|          &#39;NetVips Load, Resize, Save&#39; | 157.65 ms |  1.8562 ms | 0.4821 ms |  0.41 |    0.00 |         - |     - |     - |  122.05 KB |
</details>

With the same benchmark on Windows, NetVips is about 1.6 times slower than on Linux. That's slower than I thought, I'll do some research to see if I can improve it.

Note that the benchmark of the MagicScaler differs from the rest. This is due to the way MagicScaler processes images (YCbCr vs RGB) and which image interpolation method is being used (Catmull-Rom vs Lanczos3). For example after applying this patch:
<details><summary>Patch</summary>

```diff
@@ -47,6 +47,9 @@ namespace ImageProcessing
         {
             // Workaround ImageMagick issue
             OpenCL.IsEnabled = false;
+
+            // Most image processing libraries will use RGB for processing.
+            MagicImageProcessor.EnablePlanarPipeline = false;
         }
 
         public LoadResizeSave()
@@ -241,7 +244,10 @@ namespace ImageProcessing
                 ResizeMode = CropScaleMode.Max,
                 SaveFormat = FileFormat.Jpeg,
                 JpegQuality = Quality,
-                JpegSubsampleMode = ChromaSubsampleMode.Subsample420
+                JpegSubsampleMode = ChromaSubsampleMode.Subsample420,
+                // It's unclear which interpolation is used by default (I guess it's Catmull-Rom), 
+                // so force Lanczos3. This is in line with the other libraries.
+                Interpolation = InterpolationSettings.Lanczos
             };
 
             using (var output = new FileStream(OutputPath(input, MagicScaler), FileMode.Create))
```
</details>

The results are more in line:
<details><summary>Benchmark results on Windows after patch</summary>

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17763.475 (1809/October2018Update/Redstone5)
Intel Core i5-8600K CPU 3.60GHz (Coffee Lake), 1 CPU, 6 logical and 6 physical cores
.NET Core SDK=2.2.203
  [Host]            : .NET Core 2.2.4 (CoreCLR 4.6.27521.02, CoreFX 4.6.27521.01), 64bit RyuJIT
  .Net Core 2.2 CLI : .NET Core 2.2.4 (CoreCLR 4.6.27521.02, CoreFX 4.6.27521.01), 64bit RyuJIT

Job=.Net Core 2.2 CLI  Toolchain=.NET Core 2.2  IterationCount=5  
LaunchCount=1  WarmupCount=5  

```
|                                Method |     Mean |      Error |    StdDev | Ratio |     Gen 0 | Gen 1 | Gen 2 |  Allocated |
|-------------------------------------- |---------:|-----------:|----------:|------:|----------:|------:|------:|-----------:|
|   &#39;System.Drawing Load, Resize, Save&#39; | 375.3 ms |  3.3988 ms | 0.8827 ms |  1.00 |         - |     - |     - |    10.3 KB |
|       &#39;ImageSharp Load, Resize, Save&#39; | 253.8 ms |  0.9561 ms | 0.2483 ms |  0.68 |         - |     - |     - | 1105.16 KB |
|      &#39;ImageMagick Load, Resize, Save&#39; | 399.2 ms | 13.5677 ms | 3.5235 ms |  1.06 |         - |     - |     - |   56.13 KB |
|        &#39;ImageFree Load, Resize, Save&#39; | 316.5 ms |  1.9589 ms | 0.5087 ms |  0.84 | 6000.0000 |     - |     - |   91.73 KB |
|      &#39;MagicScaler Load, Resize, Save&#39; | 128.3 ms |  1.7519 ms | 0.4550 ms |  0.34 |         - |     - |     - |  552.72 KB |
| &#39;SkiaSharp Canvas Load, Resize, Save&#39; | 188.4 ms |  3.3828 ms | 0.8785 ms |  0.50 |         - |     - |     - |  186.96 KB |
| &#39;SkiaSharp Bitmap Load, Resize, Save&#39; | 188.4 ms |  1.7764 ms | 0.4613 ms |  0.50 |         - |     - |     - |  182.95 KB |
|          &#39;NetVips Load, Resize, Save&#39; | 156.6 ms |  2.8156 ms | 0.7312 ms |  0.42 |         - |     - |     - |  122.05 KB |
</details>

/cc @jcupitt