### PR TITLE
Fix benchmark issues and update libraries

### DIFF
--- a/NetCore/LoadResizeSaveParallel.cs
+++ b/NetCore/LoadResizeSaveParallel.cs
@@ -37,7 +37,7 @@ namespace ImageProcessing
             OperationsPerInvoke = ImagesCount*/)]
         public void MagicScalerBenchmarkParallel()
         {
-            Parallel.ForEach(Images, MagickResize);
+            Parallel.ForEach(Images, MagicScalerResize);
         }
 
         [Benchmark(Description = "SkiaSharp Canvas Load, Resize, Save - Parallel"/*,

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -1,12 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>NetCore</AssemblyName>
     <OutputType>Exe</OutputType>
     <Optimize>true</Optimize>
-    <PackageId>NetCore</PackageId>
     <RootNamespace>ImageProcessing</RootNamespace>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -16,17 +15,17 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
-    <PackageReference Include="FreeImage.Standard" Version="4.3.7" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.12.0" />
-    <PackageReference Include="NetVips" Version="1.1.0-rc1" />
+    <PackageReference Include="FreeImage.Standard" Version="4.3.8" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.14.4" />
+    <PackageReference Include="NetVips" Version="1.1.0" />
     <PackageReference Include="PhotoSauce.MagicScaler" Version="0.9.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-dev002604" />
     <PackageReference Include="SkiaSharp" Version="1.68.0" />
-    <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+    <PackageReference Include="System.Drawing.Common" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BenchmarkWithNuGetBinaries)' == 'true'">
-    <PackageReference Include="NetVips.Native" Version="8.8.0-rc2" />
+    <PackageReference Include="NetVips.Native" Version="8.8.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="1.68.0" />
   </ItemGroup>
 

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -17,8 +17,13 @@ namespace ImageProcessing
         public ShortRunWithMemoryDiagnoserConfig()
         {
             this.Add(Job.ShortRun
-                .With(CsProjCoreToolchain.NetCoreApp22)
-                .WithId(".Net Core 2.2 CLI")
+#if NETCOREAPP2_1
+                .With(CsProjCoreToolchain.NetCoreApp21)
+                .WithId(".Net Core 2.1 CLI")
+#elif NETCOREAPP3_0
+                .With(CsProjCoreToolchain.NetCoreApp30)
+                .WithId(".Net Core 3.0 CLI")
+#endif
                 .WithWarmupCount(5)
                 .WithIterationCount(5));
 


### PR DESCRIPTION
Just saw this was updated and noticed a couple of issues with the benchmarks:

1) The MagicScaler method in the parallel test was actually calling the ImageMagick implementation, making it appear ~7x slower.

2) The new NetVips resize benchmark was effectively a no-op, giving it impossibly low timings.  Because libvips is a streaming/on-demand library, no work is done until pixels are materialized.  Both the original and resized "images" in that benchmark represented the *possibility* of pixels, not any actual work.  Materializing both the original blank image and the resized image by calling `CopyMemory()` brings the benchmark more in line with the others and with NetVips' performance in the real-world (load/resize/save) tests.

**Before**

```
|                    Method |         Mean |         Error |        StdDev | Ratio | RatioSD |    Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------------------------- |-------------:|--------------:|--------------:|------:|--------:|---------:|-------:|------:|----------:|
|   'System.Drawing Resize' | 10,959.96 us |    142.284 us |    36.9506 us | 1.000 |    0.00 |        - |      - |     - |     136 B |
|       'ImageSharp Resize' |  5,932.64 us |     29.762 us |     7.7291 us | 0.541 |    0.00 |        - |      - |     - |    7440 B |
|      'ImageMagick Resize' | 51,744.23 us | 31,533.143 us | 8,189.0570 us | 4.721 |    0.74 |        - |      - |     - |    5656 B |
|        'FreeImage Resize' |  8,022.36 us |    100.563 us |    26.1159 us | 0.732 |    0.00 | 500.0000 |      - |     - |     136 B |
|      'MagicScaler Resize' |  3,599.67 us |     44.185 us |    11.4747 us | 0.328 |    0.00 |  11.7188 |      - |     - |   59525 B |
| 'SkiaSharp Canvas Resize' |  4,775.94 us |     77.787 us |    20.2010 us | 0.436 |    0.00 |        - |      - |     - |     653 B |
| 'SkiaSharp Bitmap Resize' |  4,957.65 us |  1,535.034 us |   398.6435 us | 0.452 |    0.04 |        - |      - |     - |     848 B |
|          'NetVips Resize' |     42.74 us |      1.603 us |     0.4163 us | 0.004 |    0.00 |   0.9155 | 0.4272 |     - |    5080 B |
```

**After**

```
|                    Method |      Mean |     Error |    StdDev | Ratio | RatioSD |    Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |----------:|----------:|----------:|------:|--------:|---------:|------:|------:|----------:|
|   'System.Drawing Resize' | 10.947 ms | 0.1486 ms | 0.0386 ms |  1.00 |    0.00 |        - |     - |     - |     136 B |
|       'ImageSharp Resize' |  6.086 ms | 0.2766 ms | 0.0718 ms |  0.56 |    0.01 |        - |     - |     - |    7440 B |
|      'ImageMagick Resize' | 47.676 ms | 0.6292 ms | 0.1634 ms |  4.36 |    0.02 |        - |     - |     - |    5656 B |
|        'FreeImage Resize' |  8.105 ms | 0.2517 ms | 0.0654 ms |  0.74 |    0.01 | 500.0000 |     - |     - |     136 B |
|      'MagicScaler Resize' |  3.579 ms | 0.0704 ms | 0.0183 ms |  0.33 |    0.00 |  11.7188 |     - |     - |   59525 B |
| 'SkiaSharp Canvas Resize' |  4.735 ms | 0.0373 ms | 0.0097 ms |  0.43 |    0.00 |        - |     - |     - |     650 B |
| 'SkiaSharp Bitmap Resize' |  4.754 ms | 0.0484 ms | 0.0126 ms |  0.43 |    0.00 |        - |     - |     - |     848 B |
|          'NetVips Resize' |  5.246 ms | 0.1741 ms | 0.0452 ms |  0.48 |    0.00 |        - |     - |     - |    5320 B |
```

And finally, I updated the referenced imaging libraries to their current versions and updated the `TargetFrameworks` of the project to include both LTS (2.1) and Current (3.0) framework versions.

/cc @kleisauke 