### PR TITLE
Update libraries to latest stable versions

### DIFF
--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -13,7 +13,7 @@ using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Processing;
 using SkiaSharp;
 using ImageSharpImage = SixLabors.ImageSharp.Image;
-using ImageSharpSize = SixLabors.Primitives.Size;
+using ImageSharpSize = SixLabors.ImageSharp.Size;
 using NetVipsImage = NetVips.Image;
 using SystemDrawingImage = System.Drawing.Image;
 

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>NetCore</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -17,15 +17,13 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" Condition="'$(OS)' == 'Windows_NT'" />
-    <!--<PackageReference Include="BenchmarkDotNet" Version="0.12.1.1432" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1.1432" Condition="'$(OS)' == 'Windows_NT'" />-->
-    <PackageReference Include="FreeImage.Standard" Version="4.3.9-beta4" />
+    <PackageReference Include="FreeImage.Standard" Version="4.3.8" />
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.22.0" />
     <PackageReference Include="NetVips" Version="1.2.4" />
-    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.11.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2-alpha.0.21" />
+    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.11.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.1" />
     <PackageReference Include="SkiaSharp" Version="2.80.2" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BenchmarkWithNuGetBinaries)' == 'true'">

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.22.0" />
     <PackageReference Include="NetVips" Version="1.2.4" />
     <PackageReference Include="PhotoSauce.MagicScaler" Version="0.11.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2-alpha.0.17" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2-alpha.0.21" />
     <PackageReference Include="SkiaSharp" Version="2.80.2" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.22.0" />
     <PackageReference Include="NetVips" Version="1.2.4" />
     <PackageReference Include="PhotoSauce.MagicScaler" Version="0.11.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
     <PackageReference Include="SkiaSharp" Version="2.80.2" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>NetCore</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -11,22 +11,26 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <BenchmarkWithNuGetBinaries>true</BenchmarkWithNuGetBinaries>
+    <DefineConstants>$(DefineConstants);$(OS)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
-    <PackageReference Include="FreeImage.Standard" Version="4.3.8" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.14.4" />
-    <PackageReference Include="NetVips" Version="1.1.0" />
-    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.9.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-dev002604" />
-    <PackageReference Include="SkiaSharp" Version="1.68.0" />
-    <PackageReference Include="System.Drawing.Common" Version="4.6.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" Condition="'$(OS)' == 'Windows_NT'" />
+    <!--<PackageReference Include="BenchmarkDotNet" Version="0.12.1.1432" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1.1432" Condition="'$(OS)' == 'Windows_NT'" />-->
+    <PackageReference Include="FreeImage.Standard" Version="4.3.9-beta4" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.22.0" />
+    <PackageReference Include="NetVips" Version="1.2.4" />
+    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.11.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2-alpha.0.17" />
+    <PackageReference Include="SkiaSharp" Version="2.80.2" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BenchmarkWithNuGetBinaries)' == 'true'">
-    <PackageReference Include="NetVips.Native" Version="8.8.3" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="1.68.0" />
+    <PackageReference Include="NetVips.Native" Version="8.10.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.80.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -27,7 +27,11 @@ namespace ImageProcessing
 #elif NETCOREAPP3_1
                 .WithToolchain(CsProjCoreToolchain.NetCoreApp31)
                 .WithId(".Net Core 3.1 CLI")
+#else
+                .WithToolchain(CsProjCoreToolchain.NetCoreApp50)
+                .WithId(".Net 5.0 CLI")
 #endif
+
                 .WithWarmupCount(5)
                 .WithIterationCount(5));
 

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -27,7 +27,7 @@ namespace ImageProcessing
 #elif NETCOREAPP3_1
                 .WithToolchain(CsProjCoreToolchain.NetCoreApp31)
                 .WithId(".Net Core 3.1 CLI")
-#else
+#elif NET5_0
                 .WithToolchain(CsProjCoreToolchain.NetCoreApp50)
                 .WithId(".Net 5.0 CLI")
 #endif

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -10,8 +10,10 @@ using PhotoSauce.MagicScaler;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
 using SkiaSharp;
+using Size = System.Drawing.Size;
+using Rectangle = System.Drawing.Rectangle;
 using ImageSharpImage = SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32>;
-using ImageSharpSize = SixLabors.Primitives.Size;
+using ImageSharpSize = SixLabors.ImageSharp.Size;
 
 namespace ImageProcessing
 {

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+    "sdk": {
+      "allowPrerelease": false
+    }
+}


### PR DESCRIPTION
- Updates target frameworks to include NET 5
- Updates all libraries to their latest stable versions
- Add native memory allocation tracking to the benchmarks 

_Note: There is a known issue https://github.com/dotnet/BenchmarkDotNet/issues/1561 with native allocation leak tracking that leads to incorrect reporting._