### PR TITLE
Enable running on ARM64 Linux

### DIFF
--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -5,6 +5,7 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using FreeImageAPI;
 using ImageMagick;
@@ -43,14 +44,14 @@ namespace ImageProcessing
         // TODO: https://github.com/dotnet/BenchmarkDotNet/issues/258
         public const int ImagesCount = 12;
 
-        static LoadResizeSave()
-        {
-            // Workaround ImageMagick issue
-            OpenCL.IsEnabled = false;
-        }
-
         public LoadResizeSave()
         {
+            if (RuntimeInformation.OSArchitecture is Architecture.X86 or Architecture.X64)
+            {
+                // Workaround ImageMagick issue
+                OpenCL.IsEnabled = false;
+            }
+
             // Find the closest images directory
             string imageDirectory = Path.GetFullPath(".");
             while (!Directory.Exists(Path.Combine(imageDirectory, "images")))

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>NetCore</AssemblyName>
     <OutputType>Exe</OutputType>
     <Optimize>true</Optimize>
+    <LangVersion>9</LangVersion>
     <RootNamespace>ImageProcessing</RootNamespace>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -46,7 +46,7 @@ namespace ImageProcessing
                 this.AddFilter(new NameFilter(name => !name.StartsWith("MagicScalerBenchmark")));
             }
 
-            if (RuntimeInformation.OSArchitecture is not Architecture.X86 or Architecture.X64)
+            if (RuntimeInformation.OSArchitecture is not (Architecture.X86 or Architecture.X64))
             {
                 // ImageMagick native binaries are currently only available for X86 and X64
                 this.AddFilter(new NameFilter(name => !name.StartsWith("Magick")));

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -43,12 +43,14 @@ namespace ImageProcessing
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // MagicScaler requires Windows Imaging Component (WIC) which is only available on Windows
-                this.AddFilter(new NameFilter(name => !name.StartsWith("MagicScaler")));
+                this.AddFilter(new NameFilter(name => !name.StartsWith("MagicScalerBenchmark")));
             }
 
-            // Disable this policy because the benchmarks refer
-            // to a non-optimized SkiaSharp that we do not own.
-            this.Options |= ConfigOptions.DisableOptimizationsValidator;
+            if (RuntimeInformation.OSArchitecture is not Architecture.X86 or Architecture.X64)
+            {
+                // ImageMagick native binaries are currently only available for X86 and X64
+                this.AddFilter(new NameFilter(name => !name.StartsWith("Magick")));
+            }
 
 #if Windows_NT
             if (this.IsElevated)
@@ -91,7 +93,10 @@ namespace ImageProcessing
                         var lrs = new LoadResizeSave();
                         lrs.SystemDrawingBenchmark();
                         lrs.ImageSharpBenchmark();
-                        lrs.MagickBenchmark();
+                        if (RuntimeInformation.OSArchitecture is Architecture.X86 or Architecture.X64)
+                        {
+                            lrs.MagickBenchmark();
+                        }
                         lrs.FreeImageBenchmark();
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                         {

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -149,7 +149,7 @@ namespace ImageProcessing
             const double xFactor = (double)ResizedWidth / Width;
             const double yFactor = (double)ResizedHeight / Height;
 
-            using (var original = NetVips.Image.Black(Width, Height, 3).CopyMemory())
+            using (var original = NetVips.Image.Black(Width, Height, 3))
             using (var resized = original.Resize(xFactor, vscale: yFactor, kernel: Enums.Kernel.Cubic))
             {
                 // libvips is "lazy" and will not process pixels

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -149,7 +149,7 @@ namespace ImageProcessing
             const double xFactor = (double)ResizedWidth / Width;
             const double yFactor = (double)ResizedHeight / Height;
 
-            using (var original = NetVips.Image.Black(Width, Height).CopyMemory())
+            using (var original = NetVips.Image.Black(Width, Height, 3).CopyMemory())
             using (var resized = original.Resize(xFactor, vscale: yFactor, kernel: Enums.Kernel.Cubic))
             {
                 // libvips is "lazy" and will not process pixels

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -154,7 +154,7 @@ namespace ImageProcessing
             {
                 // libvips is "lazy" and will not process pixels
                 // until you write to an output file, buffer or memory
-                var _ = resized.WriteToMemory();
+                var _ = resized.CopyMemory();
 
                 return (resized.Width, resized.Height);
             }

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -32,10 +32,10 @@ namespace ImageProcessing
             {
                 // Workaround ImageMagick issue
                 OpenCL.IsEnabled = false;
-
-                // Disable libvips operations cache
-                NetVipsUtil.CacheSetMax(0);
             }
+
+            // Disable libvips operations cache
+            NetVipsUtil.CacheSetMax(0);
         }
 
         [Benchmark(Baseline = true, Description = "System.Drawing Resize")]

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -15,6 +15,7 @@ using Size = System.Drawing.Size;
 using Rectangle = System.Drawing.Rectangle;
 using ImageSharpImage = SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32>;
 using ImageSharpSize = SixLabors.ImageSharp.Size;
+using NetVipsUtil = NetVips.NetVips;
 
 namespace ImageProcessing
 {
@@ -31,6 +32,9 @@ namespace ImageProcessing
             {
                 // Workaround ImageMagick issue
                 OpenCL.IsEnabled = false;
+
+                // Disable libvips operations cache
+                NetVipsUtil.CacheSetMax(0);
             }
         }
 


### PR DESCRIPTION
"AnyCPU" in ImageMagick's native library package name apparently only means "any CPU as long as it's x86 or x64".  I've updated the project to skip all calls to ImageMagick if not running on those platforms since binaries aren't available.  This was a particular problem because there was a call into ImageMagick's library in the static `LoadResizeSave` constructor, meaning none of the benchmarks would run if that library couldn't be loaded.

Sample results from my Raspberry Pi 4:

``` ini
BenchmarkDotNet=v0.12.1, OS=ubuntu 20.04
Unknown processor
.NET Core SDK=5.0.100
  [Host]       : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), Arm64 RyuJIT
  .Net 5.0 CLI : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), Arm64 RyuJIT

Job=.Net 5.0 CLI  Toolchain=.NET Core 5.0  IterationCount=5  LaunchCount=1  WarmupCount=5  
```

```
|                  Method |       Mean |     Error |    StdDev | Ratio |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------------------ |-----------:|----------:|----------:|------:|---------:|---------:|---------:|----------:|
|   System.Drawing Resize | 204.838 ms | 4.0268 ms | 1.0457 ms |  1.00 |        - |        - |        - |     224 B |
|       ImageSharp Resize |  40.844 ms | 0.1092 ms | 0.0169 ms |  0.20 |        - |        - |        - |    9280 B |
|        FreeImage Resize |  31.298 ms | 0.2519 ms | 0.0654 ms |  0.15 | 500.0000 | 500.0000 | 500.0000 |     504 B |
|      MagicScaler Resize |   8.783 ms | 0.0435 ms | 0.0113 ms |  0.04 |        - |        - |        - |    2352 B |
| SkiaSharp Canvas Resize |   7.299 ms | 0.0026 ms | 0.0007 ms |  0.04 |        - |        - |        - |    1445 B |
| SkiaSharp Bitmap Resize |   7.298 ms | 0.0042 ms | 0.0011 ms |  0.04 |        - |        - |        - |     512 B |
|          NetVips Resize |   9.894 ms | 0.9917 ms | 0.2575 ms |  0.05 |  15.6250 |        - |        - |   18688 B |
```

```
|                              Method |       Mean |     Error |   StdDev | Ratio | RatioSD |     Gen 0 |     Gen 1 |     Gen 2 |  Allocated |
|------------------------------------ |-----------:|----------:|---------:|------:|--------:|----------:|----------:|----------:|-----------:|
|   System.Drawing Load, Resize, Save | 1,295.9 ms |  39.23 ms | 10.19 ms |  1.00 |    0.00 |         - |         - |         - |   10.78 KB |
|       ImageSharp Load, Resize, Save | 1,560.0 ms |  21.08 ms |  3.26 ms |  1.21 |    0.01 | 1000.0000 |         - |         - | 1987.04 KB |
|        ImageFree Load, Resize, Save |   913.1 ms |  21.47 ms |  3.32 ms |  0.71 |    0.01 | 6000.0000 | 6000.0000 | 6000.0000 |   94.28 KB |
| SkiaSharp Canvas Load, Resize, Save | 1,747.9 ms | 178.77 ms | 46.43 ms |  1.35 |    0.04 |         - |         - |         - |   94.48 KB |
| SkiaSharp Bitmap Load, Resize, Save | 1,824.0 ms |  11.25 ms |  1.74 ms |  1.41 |    0.01 |         - |         - |         - |    82.3 KB |
|          NetVips Load, Resize, Save |   523.9 ms |  31.16 ms |  8.09 ms |  0.40 |    0.00 |         - |         - |         - |   46.78 KB |
```

```
|                                         Method |     Mean |     Error |   StdDev | Ratio | RatioSD |     Gen 0 |     Gen 1 |     Gen 2 |  Allocated |
|----------------------------------------------- |---------:|----------:|---------:|------:|--------:|----------:|----------:|----------:|-----------:|
|   System.Drawing Load, Resize, Save - Parallel | 521.0 ms |  32.19 ms |  8.36 ms |  1.00 |    0.00 |         - |         - |         - |   22.11 KB |
|       ImageSharp Load, Resize, Save - Parallel | 493.0 ms |  74.43 ms | 19.33 ms |  0.95 |    0.05 | 1000.0000 |         - |         - | 52312.8 KB |
|        ImageFree Load, Resize, Save - Parallel | 269.0 ms |  24.27 ms |  6.30 ms |  0.52 |    0.02 | 2000.0000 | 2000.0000 | 2000.0000 |  103.38 KB |
| SkiaSharp Canvas Load, Resize, Save - Parallel | 535.1 ms | 124.74 ms | 32.39 ms |  1.03 |    0.07 |         - |         - |         - |  106.25 KB |
| SkiaSharp Bitmap Load, Resize, Save - Parallel | 522.9 ms |  93.20 ms | 24.20 ms |  1.00 |    0.06 |         - |         - |         - |   92.89 KB |
|          NetVips Load, Resize, Save - Parallel | 193.1 ms |  27.11 ms |  7.04 ms |  0.37 |    0.02 |         - |         - |         - |    59.1 KB |
```
