### PR TITLE
Version bump

### DIFF
--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -16,19 +16,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1.1467" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1.1467" Condition="'$(OS)' == 'Windows_NT'" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1.1514" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1.1514" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="FreeImage.Standard" Version="4.3.8" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.22.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.23.2" />
     <PackageReference Include="NetVips" Version="1.2.4" />
     <PackageReference Include="PhotoSauce.MagicScaler" Version="0.11.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
     <PackageReference Include="SkiaSharp" Version="2.80.2" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BenchmarkWithNuGetBinaries)' == 'true'">
-    <PackageReference Include="NetVips.Native" Version="8.10.1" />
+    <PackageReference Include="NetVips.Native" Version="8.10.5.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.80.2" />
   </ItemGroup>
 


### PR DESCRIPTION
We just shipped a new version of [ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp/1.0.3) that's a good bit faster so I thought I would update all the libraries to their latest versions.

Current benchmarks on my SB2

#### Resize
![bm-resize-2021-02-18](https://user-images.githubusercontent.com/385879/108348592-e3493600-71d9-11eb-88d4-25b261604b65.jpg)

#### Load Resize Save
![bm-load-resize-save-2021-02-18](https://user-images.githubusercontent.com/385879/108348557-d9bfce00-71d9-11eb-8bd8-a650d949b643.jpg)

#### Load Resize Save (Parallel)
![bm-load-resize-save-parallel-2021-02-18](https://user-images.githubusercontent.com/385879/108348577-de848200-71d9-11eb-8643-a9f500cc5698.jpg)

