### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -13,6 +13,7 @@ using PhotoSauce.MagicScaler;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Processing;
 using SkiaSharp;
+using NetVips;
 using ImageSharpImage = SixLabors.ImageSharp.Image;
 using ImageSharpSize = SixLabors.ImageSharp.Size;
 using NetVipsImage = NetVips.Image;
@@ -51,6 +52,9 @@ namespace ImageProcessing
                 // Workaround ImageMagick issue
                 OpenCL.IsEnabled = false;
             }
+
+            // Disable libvips operations cache
+            Cache.Max = 0;
 
             // Find the closest images directory
             string imageDirectory = Path.GetFullPath(".");

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -16,20 +16,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1.1514" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1.1514" Condition="'$(OS)' == 'Windows_NT'" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <PackageReference Include="FreeImage.Standard" Version="4.3.8" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.23.2" />
-    <PackageReference Include="NetVips" Version="1.2.4" />
-    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.11.2" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.24.1" />
+    <PackageReference Include="NetVips" Version="2.0.1" />
+    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.12.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
     <PackageReference Include="SkiaSharp" Version="2.80.2" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.1" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BenchmarkWithNuGetBinaries)' == 'true'">
-    <PackageReference Include="NetVips.Native" Version="8.10.5.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.80.2" />
+    <PackageReference Include="NetVips.Native" Version="8.11.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.80.2" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -15,7 +15,6 @@ using Size = System.Drawing.Size;
 using Rectangle = System.Drawing.Rectangle;
 using ImageSharpImage = SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32>;
 using ImageSharpSize = SixLabors.ImageSharp.Size;
-using NetVipsUtil = NetVips.NetVips;
 
 namespace ImageProcessing
 {
@@ -35,7 +34,7 @@ namespace ImageProcessing
             }
 
             // Disable libvips operations cache
-            NetVipsUtil.CacheSetMax(0);
+            Cache.Max = 0;
         }
 
         [Benchmark(Baseline = true, Description = "System.Drawing Resize")]


### PR DESCRIPTION
This PR updates the dependencies to their latest versions and also disables libvips' operations cache in the `Load, Resize, Save*` benchmark.

libvips should run slightly faster in these benchmarks, since threads are now reused rather then being constantly created and destroyed, see:
https://libvips.github.io/libvips/2021/06/04/What's-new-in-8.11.html#thread-recycling

<details>
  <summary>Benchmark results</summary>
  
```ini
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19043.1052 (21H1/May2021Update)
Intel Core i5-8600K CPU 3.60GHz (Coffee Lake), 1 CPU, 6 logical and 6 physical cores
.NET SDK=5.0.301
  [Host]       : .NET 5.0.7 (5.0.721.25508), X64 RyuJIT
  .Net 5.0 CLI : .NET 5.0.7 (5.0.721.25508), X64 RyuJIT

Job=.Net 5.0 CLI  Arguments=/p:DebugType=portable  Toolchain=.NET 5.0  
IterationCount=5  LaunchCount=1  WarmupCount=5  
```

```
|                    Method |        Mean |       Error |    StdDev | Ratio | RatioSD |    Gen 0 |    Gen 1 |    Gen 2 | Allocated | Allocated native memory | Native memory leak |
|-------------------------- |------------:|------------:|----------:|------:|--------:|---------:|---------:|---------:|----------:|------------------------:|-------------------:|
|   'System.Drawing Resize' | 10,219.8 us |   416.59 us | 108.19 us |  1.00 |    0.00 |        - |        - |        - |     136 B |               123,988 B |                  - |
|       'ImageSharp Resize' |  2,541.9 us |    17.75 us |   2.75 us |  0.25 |    0.00 |        - |        - |        - |   9,084 B |                       - |                  - |
|      'ImageMagick Resize' | 47,949.9 us | 1,022.49 us | 265.54 us |  4.69 |    0.06 |        - |        - |        - |   5,336 B |             8,853,933 B |                  - |
|        'FreeImage Resize' |  7,204.6 us |    90.01 us |  23.38 us |  0.71 |    0.01 | 500.0000 | 500.0000 | 500.0000 |     136 B |             3,785,021 B |                  - |
|      'MagicScaler Resize' |    711.0 us |     3.28 us |   0.85 us |  0.07 |    0.00 |        - |        - |        - |   1,661 B |                       - |                  - |
| 'SkiaSharp Canvas Resize' |  1,768.4 us |    15.87 us |   2.46 us |  0.17 |    0.00 |        - |        - |        - |   1,504 B |             5,888,000 B |            2,840 B |
| 'SkiaSharp Bitmap Resize' |  1,773.6 us |     7.11 us |   1.85 us |  0.17 |    0.00 |        - |        - |        - |     488 B |             5,947,880 B |            2,840 B |
|          'NetVips Resize' |  4,995.3 us |    14.46 us |   3.76 us |  0.49 |    0.01 |        - |        - |        - |   4,152 B |             1,178,006 B |           46,020 B |
```

```
|                                Method |      Mean |     Error |   StdDev | Ratio |     Gen 0 |     Gen 1 |     Gen 2 | Allocated | Allocated native memory | Native memory leak |
|-------------------------------------- |----------:|----------:|---------:|------:|----------:|----------:|----------:|----------:|------------------------:|-------------------:|
|   'System.Drawing Load, Resize, Save' | 369.07 ms |  7.530 ms | 1.956 ms |  1.00 |         - |         - |         - |     12 KB |               11,374 KB |             738 KB |
|       'ImageSharp Load, Resize, Save' | 150.72 ms |  3.708 ms | 0.963 ms |  0.41 |         - |         - |         - |  1,987 KB |                    9 KB |                  - |
|      'ImageMagick Load, Resize, Save' | 396.11 ms | 11.279 ms | 1.745 ms |  1.07 |         - |         - |         - |     54 KB |               61,238 KB |                  - |
|        'ImageFree Load, Resize, Save' | 246.46 ms |  2.436 ms | 0.632 ms |  0.67 | 6000.0000 | 6000.0000 | 6000.0000 |     93 KB |               49,137 KB |              58 KB |
|      'MagicScaler Load, Resize, Save' |  65.22 ms |  0.951 ms | 0.247 ms |  0.18 |         - |         - |         - |     47 KB |                3,087 KB |             178 KB |
| 'SkiaSharp Canvas Load, Resize, Save' | 232.08 ms |  3.393 ms | 0.881 ms |  0.63 |         - |         - |         - |     97 KB |               69,710 KB |           1,055 KB |
| 'SkiaSharp Bitmap Load, Resize, Save' | 232.26 ms |  2.440 ms | 0.634 ms |  0.63 |         - |         - |         - |     84 KB |               70,424 KB |             343 KB |
|          'NetVips Load, Resize, Save' | 117.05 ms |  2.827 ms | 0.438 ms |  0.32 |         - |         - |         - |     52 KB |               27,626 KB |               0 KB |
```

```
|                                           Method |      Mean |     Error |   StdDev | Ratio | RatioSD |     Gen 0 |     Gen 1 |     Gen 2 | Allocated | Allocated native memory | Native memory leak |
|------------------------------------------------- |----------:|----------:|---------:|------:|--------:|----------:|----------:|----------:|----------:|------------------------:|-------------------:|
|   'System.Drawing Load, Resize, Save - Parallel' | 130.95 ms | 14.778 ms | 2.287 ms |  1.00 |    0.00 |         - |         - |         - |     29 KB |                1,490 KB |              75 KB |
|       'ImageSharp Load, Resize, Save - Parallel' |  33.68 ms |  2.189 ms | 0.569 ms |  0.26 |    0.00 |  400.0000 |  133.3333 |         - |  2,557 KB |                    4 KB |                  - |
|      'ImageMagick Load, Resize, Save - Parallel' |  91.61 ms | 14.653 ms | 3.805 ms |  0.70 |    0.04 |         - |         - |         - |     76 KB |                6,982 KB |                  - |
|        'ImageFree Load, Resize, Save - Parallel' |  52.81 ms |  3.749 ms | 0.974 ms |  0.41 |    0.01 | 5100.0000 | 5100.0000 | 5100.0000 |    111 KB |                4,734 KB |               8 KB |
|      'MagicScaler Load, Resize, Save - Parallel' |  14.43 ms |  0.215 ms | 0.033 ms |  0.11 |    0.00 |   15.6250 |         - |         - |     78 KB |                  209 KB |              14 KB |
| 'SkiaSharp Canvas Load, Resize, Save - Parallel' |  46.91 ms |  4.282 ms | 1.112 ms |  0.36 |    0.01 |         - |         - |         - |    118 KB |               12,898 KB |             136 KB |
| 'SkiaSharp Bitmap Load, Resize, Save - Parallel' |  47.07 ms |  1.744 ms | 0.453 ms |  0.36 |    0.01 |         - |         - |         - |    119 KB |               11,581 KB |               5 KB |
|          'NetVips Load, Resize, Save - Parallel' |  36.31 ms |  5.346 ms | 1.388 ms |  0.28 |    0.01 |         - |         - |         - |     73 KB |                2,649 KB |                  - |
```
</details>

/cc @jcupitt, as he might be interested in the above numbers.