### PR TITLE
Version updates

### DIFF
--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>NetCore</AssemblyName>
     <OutputType>Exe</OutputType>
     <Optimize>true</Optimize>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
     <RootNamespace>ImageProcessing</RootNamespace>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -16,19 +16,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1.1695" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1.1695" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <PackageReference Include="FreeImage.Standard" Version="4.3.8" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="7.24.1" />
-    <PackageReference Include="NetVips" Version="2.0.1" />
-    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.12.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
-    <PackageReference Include="SkiaSharp" Version="2.80.2" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="9.1.1" />
+    <PackageReference Include="NetVips" Version="2.1.0" />
+    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.12.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
+    <PackageReference Include="SkiaSharp" Version="2.80.3" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BenchmarkWithNuGetBinaries)' == 'true'">
-    <PackageReference Include="NetVips.Native" Version="8.11.0" />
+    <PackageReference Include="NetVips.Native" Version="8.12.2" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.80.2" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
   </ItemGroup>
 


### PR DESCRIPTION
ImageSharp V2 just released so I thought it'd be a good idea to give this a bump. I updated the other libraries also and changed the target framework to .NET 6.

I've struggled to get stable benchmarks on my battered old laptop so I'd love to see what the numbers are looking at on other machines if anyone has the chance. 