### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -36,7 +36,6 @@ namespace ImageProcessing
         private const string NetVips = nameof(NetVips);
         private const string FreeImage = nameof(FreeImage);
         private const string MagicScaler = nameof(MagicScaler);
-        private const string SkiaSharpCanvas = nameof(SkiaSharpCanvas);
         private const string SkiaSharpBitmap = nameof(SkiaSharpBitmap);
 
         // Set the quality for ImagSharp

--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -369,23 +369,10 @@ namespace ImageProcessing
         public void NetVipsResize(string input)
         {
             // Thumbnail to fit a 150x150 square
-            using (var thumb = NetVipsImage.Thumbnail(input, ThumbnailSize, ThumbnailSize))
-            {
-                // Remove all metadata except color profile
-                using var mutated = thumb.Mutate(mutable =>
-                {
-                    foreach (var field in mutable.GetFields())
-                    {
-                        if (field == "icc-profile-data")
-                            continue;
+            using var thumb = NetVipsImage.Thumbnail(input, ThumbnailSize, ThumbnailSize);
 
-                        mutable.Remove(field);
-                    }
-                });
-
-                // Save the results
-                mutated.Jpegsave(OutputPath(input, NetVips), q: Quality);
-            }
+            // Save the results
+            thumb.Jpegsave(OutputPath(input, NetVips), q: Quality, keep: Enums.ForeignKeep.Icc);
         }
     }
 }

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>NetCore</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -16,21 +16,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.8" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.11" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <PackageReference Include="FreeImage.Standard" Version="4.3.8" />
     <PackageReference Include="Imageflow.AllPlatforms" Version="0.10.2" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.3.0" />
-    <PackageReference Include="NetVips" Version="2.3.1" />
-    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.13.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.5.0" />
+    <PackageReference Include="NetVips" Version="2.4.0" />
+    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.14.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.1" />
     <PackageReference Include="SkiaSharp" Version="2.88.6" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.3" /> <!-- 6+ has no improvements and disables Linux support -->
   </ItemGroup>
 
   <ItemGroup Condition="'$(BenchmarkWithNuGetBinaries)' == 'true'">
-    <PackageReference Include="NetVips.Native" Version="8.14.5" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="NetVips.Native" Version="8.15.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -22,12 +22,7 @@ namespace ImageProcessing
         {
             this.AddJob(Job.ShortRun
                 .WithWarmupCount(5)
-                .WithIterationCount(5)
-                .WithArguments(new Argument[]
-                {
-                    // See https://github.com/dotnet/roslyn/issues/42393
-                    new MsBuildArgument("/p:DebugType=portable")
-                }));
+                .WithIterationCount(5));
 
             this.AddColumnProvider(DefaultColumnProviders.Instance);
             this.AddLogger(ConsoleLogger.Default);
@@ -54,8 +49,7 @@ namespace ImageProcessing
             }
 
 #if Windows_NT
-            // See https://github.com/microsoft/perfview/issues/1264
-            if (this.IsElevated && RuntimeInformation.OSArchitecture != Architecture.Arm64)
+            if (this.IsElevated)
             {
                 this.AddDiagnoser(new NativeMemoryProfiler());
             }

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -35,6 +35,12 @@ namespace ImageProcessing
                 this.AddFilter(new NameFilter(name => !name.StartsWith("MagicScalerBenchmark")));
             }
 
+            if (RuntimeInformation.OSArchitecture is not (Architecture.X86 or Architecture.X64))
+            {
+                // ImageFlow native binaries are currently only available for X86 and X64
+                this.AddFilter(new NameFilter(name => !name.StartsWith("ImageFlow")));
+            }
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
                 RuntimeInformation.OSArchitecture == Architecture.Arm64)
             {

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -35,12 +35,6 @@ namespace ImageProcessing
                 this.AddFilter(new NameFilter(name => !name.StartsWith("MagicScalerBenchmark")));
             }
 
-            if (RuntimeInformation.OSArchitecture is not (Architecture.X86 or Architecture.X64))
-            {
-                // ImageMagick native binaries are currently only available for X86 and X64
-                this.AddFilter(new NameFilter(name => !name.StartsWith("Magick")));
-            }
-
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
                 RuntimeInformation.OSArchitecture == Architecture.Arm64)
             {
@@ -92,10 +86,10 @@ namespace ImageProcessing
                         lrs.SystemDrawingBenchmark();
                         lrs.ImageSharpBenchmark();
                         lrs.ImageSharpTargetedDecodeBenchmark();
+                        lrs.MagickBenchmark();
                         if (RuntimeInformation.OSArchitecture is Architecture.X86 or Architecture.X64)
                         {
                             await lrs.ImageFlowBenchmark();
-                            lrs.MagickBenchmark();
                         }
                         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
                             RuntimeInformation.OSArchitecture != Architecture.Arm64)

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -151,15 +151,14 @@ namespace ImageProcessing
             const double xFactor = (double)ResizedWidth / Width;
             const double yFactor = (double)ResizedHeight / Height;
 
-            using (var original = NetVips.Image.Black(Width, Height, 3))
-            using (var resized = original.Resize(xFactor, vscale: yFactor, kernel: Enums.Kernel.Cubic))
-            {
-                // libvips is "lazy" and will not process pixels
-                // until you write to an output file, buffer or memory
-                var _ = resized.CopyMemory();
+            using var original = NetVips.Image.Black(Width, Height, 3);
+            using var resized = original.Resize(xFactor, vscale: yFactor, kernel: Enums.Kernel.Cubic, gap: 0.0);
 
-                return (resized.Width, resized.Height);
-            }
+            // libvips is "lazy" and will not process pixels
+            // until you write to an output file, buffer or memory
+            _ = resized.CopyMemory();
+
+            return (resized.Width, resized.Height);
         }
     }
 }


### PR DESCRIPTION
This PR updates the dependencies to their latest versions and includes a few other minor improvements. See the individual commits for more details.

NetVips is expected to perform faster due to recent performance improvements in libvips, as detailed here:
https://libvips.org/2023/10/10/What's-new-in-8.15.html#performance-improvements

<details><summary>Benchmark results on Linux</summary>

```

BenchmarkDotNet v0.13.11, Fedora Linux 39 (Workstation Edition)
AMD Ryzen 9 7900, 1 CPU, 24 logical and 12 physical cores
.NET SDK 8.0.100
  [Host]   : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  ShortRun : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Job=ShortRun  IterationCount=5  LaunchCount=1  
WarmupCount=5  

```

```
| Method                              | Mean      | Error     | StdDev   | Ratio | RatioSD | Gen0      | Gen1      | Gen2      | Allocated  | Alloc Ratio |
|------------------------------------ |----------:|----------:|---------:|------:|--------:|----------:|----------:|----------:|-----------:|------------:|
| 'System.Drawing Load, Resize, Save' | 166.05 ms |  6.456 ms | 1.677 ms |  1.00 |    0.00 |         - |         - |         - |    11.9 KB |        1.00 |
| 'ImageFlow Load, Resize, Save'      | 162.00 ms |  0.676 ms | 0.105 ms |  0.97 |    0.01 |  750.0000 |  750.0000 |  750.0000 | 4639.66 KB |      389.94 |
| 'ImageSharp Load, Resize, Save'     |  98.97 ms | 22.783 ms | 3.526 ms |  0.59 |    0.02 |         - |         - |         - | 1318.42 KB |      110.81 |
| 'ImageSharp TD Load, Resize, Save'  |  44.77 ms |  0.084 ms | 0.022 ms |  0.27 |    0.00 |         - |         - |         - | 1311.44 KB |      110.22 |
| 'ImageMagick Load, Resize, Save'    | 221.63 ms |  2.014 ms | 0.312 ms |  1.33 |    0.01 |         - |         - |         - |   53.02 KB |        4.46 |
| 'ImageFree Load, Resize, Save'      | 128.17 ms |  0.149 ms | 0.039 ms |  0.77 |    0.01 | 6000.0000 | 6000.0000 | 6000.0000 |  100.18 KB |        8.42 |
| 'SkiaSharp Load, Resize, Save'      |  75.73 ms |  0.062 ms | 0.010 ms |  0.45 |    0.00 |         - |         - |         - |   94.07 KB |        7.91 |
| 'NetVips Load, Resize, Save'        |  52.33 ms |  0.789 ms | 0.205 ms |  0.32 |    0.00 |         - |         - |         - |   48.86 KB |        4.11 |
```

</details>

<details><summary>Benchmark results on Windows</summary>

```

BenchmarkDotNet v0.13.11, Windows 11 (10.0.22631.2861/23H2/2023Update/SunValley3)
AMD Ryzen 9 7900, 1 CPU, 24 logical and 12 physical cores
.NET SDK 8.0.100
  [Host]   : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  ShortRun : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Job=ShortRun  IterationCount=5  LaunchCount=1  
WarmupCount=5  

```

```
| Method                              | Mean      | Error    | StdDev   | Ratio | Gen0      | Allocated native memory | Native memory leak | Gen1      | Gen2      | Allocated  | Alloc Ratio |
|------------------------------------ |----------:|---------:|---------:|------:|----------:|------------------------:|-------------------:|----------:|----------:|-----------:|------------:|
| 'System.Drawing Load, Resize, Save' | 222.73 ms | 1.140 ms | 0.176 ms |  1.00 |         - |               11,374 KB |             738 KB |         - |         - |   12.03 KB |        1.00 |
| 'ImageFlow Load, Resize, Save'      | 171.04 ms | 3.150 ms | 0.487 ms |  0.77 |  666.6667 |                    5 KB |                  - |  666.6667 |  666.6667 | 4641.82 KB |      385.91 |
| 'ImageSharp Load, Resize, Save'     |  73.60 ms | 1.514 ms | 0.393 ms |  0.33 |         - |                    9 KB |               0 KB |         - |         - |  1318.7 KB |      109.63 |
| 'ImageSharp TD Load, Resize, Save'  |  44.16 ms | 0.530 ms | 0.138 ms |  0.20 |         - |                    8 KB |                  - |         - |         - | 1311.89 KB |      109.07 |
| 'ImageMagick Load, Resize, Save'    | 240.08 ms | 5.421 ms | 1.408 ms |  1.08 |         - |               60,434 KB |                  - |         - |         - |   53.08 KB |        4.41 |
| 'ImageFree Load, Resize, Save'      | 170.91 ms | 2.351 ms | 0.611 ms |  0.77 | 6000.0000 |               49,137 KB |                  - | 6000.0000 | 6000.0000 |   95.25 KB |        7.92 |
| 'MagicScaler Load, Resize, Save'    |  39.33 ms | 0.230 ms | 0.036 ms |  0.18 |         - |                3,067 KB |                  - |         - |         - |   44.55 KB |        3.70 |
| 'SkiaSharp Load, Resize, Save'      |  87.32 ms | 0.888 ms | 0.137 ms |  0.39 |         - |               70,468 KB |             190 KB |         - |         - |   94.39 KB |        7.85 |
| 'NetVips Load, Resize, Save'        |  60.87 ms | 1.233 ms | 0.320 ms |  0.27 |         - |                8,234 KB |               0 KB |         - |         - |   49.18 KB |        4.09 |
```
</details>

<details><summary>Benchmark results on Windows ARM64 (Raspberry Pi 4B w/ 4GB ram)</summary>

```

BenchmarkDotNet v0.13.11, Windows 10 (10.0.19045.3803/22H2/2022Update)
BCM2711 (ARM Cortex-A72), 1 CPU, 4 logical and 4 physical cores
.NET SDK 8.0.100
  [Host]   : .NET 8.0.0 (8.0.23.53103), Arm64 RyuJIT AdvSIMD
  ShortRun : .NET 8.0.0 (8.0.23.53103), Arm64 RyuJIT AdvSIMD

Job=ShortRun  IterationCount=5  LaunchCount=1  
WarmupCount=5  

```

```
| Method                              | Mean       | Error     | StdDev    | Ratio | RatioSD | Allocated native memory | Native memory leak | Allocated  | Alloc Ratio |
|------------------------------------ |-----------:|----------:|----------:|------:|--------:|------------------------:|-------------------:|-----------:|------------:|
| 'System.Drawing Load, Resize, Save' | 1,333.4 ms | 273.06 ms |  42.26 ms |  1.00 |    0.00 |               11,334 KB |             738 KB |   11.35 KB |        1.00 |
| 'ImageSharp Load, Resize, Save'     | 1,385.7 ms | 160.55 ms |  41.69 ms |  1.04 |    0.04 |                   12 KB |                  - | 1415.61 KB |      124.71 |
| 'ImageSharp TD Load, Resize, Save'  |   491.3 ms |  40.96 ms |  10.64 ms |  0.37 |    0.01 |                   39 KB |               1 KB | 1408.97 KB |      124.12 |
| 'ImageMagick Load, Resize, Save'    | 2,918.0 ms | 945.69 ms | 245.59 ms |  2.22 |    0.15 |               59,334 KB |                  - |    52.6 KB |        4.63 |
| 'MagicScaler Load, Resize, Save'    |   389.9 ms |  64.28 ms |   9.95 ms |  0.29 |    0.00 |                3,067 KB |               0 KB |   50.76 KB |        4.47 |
| 'SkiaSharp Load, Resize, Save'      |   685.6 ms | 161.10 ms |  41.84 ms |  0.51 |    0.04 |               69,325 KB |             948 KB |   85.17 KB |        7.50 |
| 'NetVips Load, Resize, Save'        |   549.2 ms |  49.36 ms |  12.82 ms |  0.41 |    0.02 |                  412 KB |                  - |   48.76 KB |        4.30 |
```
</details>

/cc @jcupitt, as he might be interested in the above benchmarks.
