### PR TITLE
Enable MagicScaler cross-platform

### DIFF
--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -12,6 +12,7 @@ using FreeImageAPI;
 using ImageMagick;
 using NetVips;
 using PhotoSauce.MagicScaler;
+using PhotoSauce.NativeCodecs.Libjpeg;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Processing;
@@ -59,6 +60,14 @@ namespace ImageProcessing
 
             // Disable libvips operations cache
             Cache.Max = 0;
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // Use xplat JPEG codec for MagicScaler
+                CodecManager.Configure(codecs => {
+                    codecs.UseLibjpeg();
+                });
+            }
 
             // Find the closest images directory
             string imageDirectory = Path.GetFullPath(".");

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.5.0" />
     <PackageReference Include="NetVips" Version="2.4.0" />
     <PackageReference Include="PhotoSauce.MagicScaler" Version="0.14.0" />
+    <PackageReference Include="PhotoSauce.NativeCodecs.Libjpeg" Version="3.0.0-preview1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.1" />
     <PackageReference Include="SkiaSharp" Version="2.88.6" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.3" /> <!-- 6+ has no improvements and disables Linux support -->

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="Imageflow.AllPlatforms" Version="0.10.2" />
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.5.0" />
     <PackageReference Include="NetVips" Version="2.4.0" />
-    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.14.0" />
-    <PackageReference Include="PhotoSauce.NativeCodecs.Libjpeg" Version="3.0.0-preview1" />
+    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.14.1" />
+    <PackageReference Include="PhotoSauce.NativeCodecs.Libjpeg" Version="3.0.2-preview1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.1" />
     <PackageReference Include="SkiaSharp" Version="2.88.6" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.3" /> <!-- 6+ has no improvements and disables Linux support -->

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -29,9 +29,9 @@ namespace ImageProcessing
             this.AddExporter(MarkdownExporter.GitHub);
             this.AddDiagnoser(MemoryDiagnoser.Default);
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                // MagicScaler requires Windows Imaging Component (WIC) which is only available on Windows
+                // MagicScaler does not currently have native codecs available for macOS
                 this.AddFilter(new NameFilter(name => !name.StartsWith("MagicScalerBenchmark")));
             }
 
@@ -102,7 +102,7 @@ namespace ImageProcessing
                         {
                             lrs.FreeImageBenchmark();
                         }
-                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                         {
                             lrs.MagicScalerBenchmark();
                         }


### PR DESCRIPTION
Added native codec package for MagicScaler so it can run on Linux.

Some updated benchmark numbers:

<details><summary>Arm64 Linux (Raspberry Pi 5)</summary>

```
BenchmarkDotNet v0.13.11, Ubuntu 23.10 (Mantic Minotaur)
Unknown processor
.NET SDK 8.0.101
  [Host]   : .NET 8.0.1 (8.0.123.58001), Arm64 RyuJIT AdvSIMD
  ShortRun : .NET 8.0.1 (8.0.123.58001), Arm64 RyuJIT AdvSIMD

Job=ShortRun  IterationCount=5  LaunchCount=1
WarmupCount=5

| Method                              | Mean     | Error    | StdDev  | Ratio | Gen0      | Gen1      | Gen2      | Allocated  | Alloc Ratio |
|------------------------------------ |---------:|---------:|--------:|------:|----------:|----------:|----------:|-----------:|------------:|
| 'System.Drawing Load, Resize, Save' | 615.0 ms | 23.08 ms | 3.57 ms |  1.00 |         - |         - |         - |   10.47 KB |        1.00 |
| 'ImageSharp Load, Resize, Save'     | 458.1 ms |  1.51 ms | 0.39 ms |  0.75 |         - |         - |         - |    1415 KB |      135.16 |
| 'ImageSharp TD Load, Resize, Save'  | 168.2 ms |  2.05 ms | 0.53 ms |  0.27 |  666.6667 |         - |         - | 1407.38 KB |      134.44 |
| 'ImageMagick Load, Resize, Save'    | 912.0 ms |  1.95 ms | 0.51 ms |  1.48 |         - |         - |         - |   51.33 KB |        4.90 |
| 'ImageFree Load, Resize, Save'      | 362.0 ms |  4.56 ms | 0.70 ms |  0.59 | 6000.0000 | 6000.0000 | 6000.0000 |   96.31 KB |        9.20 |
| 'MagicScaler Load, Resize, Save'    | 105.5 ms |  0.83 ms | 0.22 ms |  0.17 |         - |         - |         - |   43.78 KB |        4.18 |
| 'SkiaSharp Load, Resize, Save'      | 154.3 ms |  0.66 ms | 0.10 ms |  0.25 |         - |         - |         - |   82.62 KB |        7.89 |
| 'NetVips Load, Resize, Save'        | 191.7 ms |  6.51 ms | 1.69 ms |  0.31 |         - |         - |         - |   46.04 KB |        4.40 |
```
</details>

<details><summary>Arm64 Windows (Dev Kit 2023)</summary>

```
BenchmarkDotNet v0.13.11, Windows 11 (10.0.22621.3007/22H2/2022Update/SunValley2)
Snapdragon Compute Platform, 1 CPU, 8 logical and 8 physical cores
.NET SDK 8.0.200-preview.23624.5
  [Host]   : .NET 8.0.0 (8.0.23.53103), Arm64 RyuJIT AdvSIMD
  ShortRun : .NET 8.0.0 (8.0.23.53103), Arm64 RyuJIT AdvSIMD

Job=ShortRun  IterationCount=5  LaunchCount=1
WarmupCount=5

| Method                              | Mean      | Error     | StdDev   | Ratio | Allocated  | Alloc Ratio |
|------------------------------------ |----------:|----------:|---------:|------:|-----------:|------------:|
| 'System.Drawing Load, Resize, Save' | 378.03 ms |  5.563 ms | 1.445 ms |  1.00 |    9.48 KB |        1.00 |
| 'ImageSharp Load, Resize, Save'     | 268.76 ms |  5.641 ms | 1.465 ms |  0.71 | 1416.16 KB |      149.44 |
| 'ImageSharp TD Load, Resize, Save'  | 108.49 ms | 13.507 ms | 3.508 ms |  0.29 |  1409.7 KB |      148.76 |
| 'ImageMagick Load, Resize, Save'    | 573.80 ms | 14.409 ms | 3.742 ms |  1.52 |   50.06 KB |        5.28 |
| 'MagicScaler Load, Resize, Save'    |  64.43 ms |  0.917 ms | 0.238 ms |  0.17 |   42.63 KB |        4.50 |
| 'SkiaSharp Load, Resize, Save'      | 152.44 ms |  1.900 ms | 0.493 ms |  0.40 |   83.74 KB |        8.84 |
| 'NetVips Load, Resize, Save'        | 119.30 ms |  8.212 ms | 1.271 ms |  0.32 |   44.51 KB |        4.70 |
```
</details>

<details><summary>x64 Linux (WSL2)</summary>

```
BenchmarkDotNet v0.13.11, Ubuntu 22.04.3 LTS (Jammy Jellyfish) WSL
Intel Xeon W-11855M CPU 3.20GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK 8.0.101
  [Host]   : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  ShortRun : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Job=ShortRun  IterationCount=5  LaunchCount=1
WarmupCount=5

| Method                              | Mean     | Error    | StdDev  | Ratio | RatioSD | Gen0     | Gen1     | Gen2     | Allocated  | Alloc Ratio |
|------------------------------------ |---------:|---------:|--------:|------:|--------:|---------:|---------:|---------:|-----------:|------------:|
| 'System.Drawing Load, Resize, Save' | 248.7 ms | 17.08 ms | 4.44 ms |  1.00 |    0.00 |        - |        - |        - |   10.86 KB |        1.00 |
| 'ImageFlow Load, Resize, Save'      | 261.7 ms |  6.48 ms | 1.68 ms |  1.05 |    0.01 | 500.0000 | 500.0000 | 500.0000 | 4638.84 KB |      427.17 |
| 'ImageSharp Load, Resize, Save'     | 186.5 ms | 28.55 ms | 7.41 ms |  0.75 |    0.02 |        - |        - |        - | 1314.36 KB |      121.03 |
| 'ImageSharp TD Load, Resize, Save'  | 145.5 ms | 10.03 ms | 2.60 ms |  0.59 |    0.01 |        - |        - |        - | 1307.83 KB |      120.43 |
| 'ImageMagick Load, Resize, Save'    | 501.5 ms |  6.97 ms | 1.08 ms |  2.02 |    0.04 |        - |        - |        - |   52.09 KB |        4.80 |
| 'ImageFree Load, Resize, Save'      |       NA |       NA |      NA |     ? |       ? |       NA |       NA |       NA |         NA |           ? |
| 'MagicScaler Load, Resize, Save'    | 102.6 ms |  2.76 ms | 0.72 ms |  0.41 |    0.00 |        - |        - |        - |   44.03 KB |        4.05 |
| 'SkiaSharp Load, Resize, Save'      | 340.2 ms |  5.01 ms | 1.30 ms |  1.37 |    0.02 |        - |        - |        - |   87.91 KB |        8.09 |
| 'NetVips Load, Resize, Save'        | 381.8 ms |  7.51 ms | 1.16 ms |  1.54 |    0.03 |        - |        - |        - |    47.8 KB |        4.40 |
```

*FreeImage failed due to missing dependencies.  It links old libraries no longer available in Ubuntu's package manager.
</details>

<details><summary>x64 Windows</summary>

```
BenchmarkDotNet v0.13.11, Windows 10 (10.0.19045.3803/22H2/2022Update)
Intel Xeon W-11855M CPU 3.20GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK 8.0.200-preview.23624.5
  [Host]   : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  ShortRun : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Job=ShortRun  IterationCount=5  LaunchCount=1
WarmupCount=5

| Method                              | Mean      | Error     | StdDev   | Ratio | Gen0      | Gen1      | Gen2      | Allocated  | Alloc Ratio |
|------------------------------------ |----------:|----------:|---------:|------:|----------:|----------:|----------:|-----------:|------------:|
| 'System.Drawing Load, Resize, Save' | 345.59 ms | 15.645 ms | 2.421 ms |  1.00 |         - |         - |         - |    10.6 KB |        1.00 |
| 'ImageFlow Load, Resize, Save'      | 226.45 ms |  5.221 ms | 1.356 ms |  0.66 |  666.6667 |  666.6667 |  666.6667 | 4640.65 KB |      437.73 |
| 'ImageSharp Load, Resize, Save'     | 106.97 ms |  9.298 ms | 2.415 ms |  0.31 |         - |         - |         - | 1313.25 KB |      123.87 |
| 'ImageSharp TD Load, Resize, Save'  |  67.48 ms |  5.912 ms | 1.535 ms |  0.19 |         - |         - |         - |  1305.8 KB |      123.17 |
| 'ImageMagick Load, Resize, Save'    | 337.77 ms | 15.448 ms | 2.391 ms |  0.98 |         - |         - |         - |   51.38 KB |        4.85 |
| 'ImageFree Load, Resize, Save'      | 209.88 ms | 11.169 ms | 1.728 ms |  0.61 | 6000.0000 | 6000.0000 | 6000.0000 |   94.12 KB |        8.88 |
| 'MagicScaler Load, Resize, Save'    |  50.63 ms |  4.482 ms | 0.694 ms |  0.15 |         - |         - |         - |    43.3 KB |        4.08 |
| 'SkiaSharp Load, Resize, Save'      | 120.01 ms |  7.916 ms | 2.056 ms |  0.35 |         - |         - |         - |   86.88 KB |        8.20 |
| 'NetVips Load, Resize, Save'        |  87.80 ms |  2.486 ms | 0.385 ms |  0.25 |         - |         - |         - |    46.4 KB |        4.38 |
```
</details>