### PR TITLE
Bump SixLabors.ImageSharp from 3.1.3 to 3.1.5 in /NetCore 

### DIFF
--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Imageflow.AllPlatforms" Version="0.10.2" />
     <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.5.0" />
     <PackageReference Include="NetVips" Version="2.4.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="PhotoSauce.MagicScaler" Version="0.14.1" />
     <PackageReference Include="PhotoSauce.NativeCodecs.Libjpeg" Version="3.0.2-preview1" />
     <PackageReference Include="SkiaSharp" Version="2.88.6" />


### PR DESCRIPTION
Update ImageSharp to latest version for performance improvements.