### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -348,7 +348,7 @@ namespace ImageProcessing
             using (var original = SKBitmap.Decode(input))
             {
                 var scaled = ScaledSize(original.Width, original.Height, ThumbnailSize);
-                using (var resized = original.Resize(new SKImageInfo(scaled.width, scaled.height), SKFilterQuality.High))
+                using (var resized = original.Resize(new SKImageInfo(scaled.width, scaled.height), new SKSamplingOptions(SKCubicResampler.Mitchell)))
                 {
                     if (resized == null)
                     {

--- a/NetCore/LoadResizeSave.cs
+++ b/NetCore/LoadResizeSave.cs
@@ -21,6 +21,7 @@ using ImageFlow = Imageflow.Fluent;
 using ImageSharpImage = SixLabors.ImageSharp.Image;
 using ImageSharpSize = SixLabors.ImageSharp.Size;
 using NetVipsImage = NetVips.Image;
+using NetVipsUtils = NetVips.NetVips;
 using SystemDrawingImage = System.Drawing.Image;
 
 namespace ImageProcessing
@@ -60,6 +61,9 @@ namespace ImageProcessing
 
             // Disable libvips operations cache
             Cache.Max = 0;
+
+            // Reduce concurrency in libvips, as a large thread pool can slow down overall processing
+            NetVipsUtils.Concurrency = 4;
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/NetCore/LoadResizeSaveParallel.cs
+++ b/NetCore/LoadResizeSaveParallel.cs
@@ -5,7 +5,7 @@ namespace ImageProcessing
 {
     public class LoadResizeSaveParallel : LoadResizeSave
     {
-        [Benchmark(Baseline = true, Description = "System.Drawing Load, Resize, Save - Parallel"/*,
+        [Benchmark(Description = "System.Drawing Load, Resize, Save - Parallel"/*,
             OperationsPerInvoke = ImagesCount*/)]
         public void SystemDrawingBenchmarkParallel()
         {

--- a/NetCore/NetCore.csproj
+++ b/NetCore/NetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>NetCore</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -16,22 +16,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.11" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <PackageReference Include="FreeImage.Standard" Version="4.3.8" />
-    <PackageReference Include="Imageflow.AllPlatforms" Version="0.10.2" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.5.0" />
-    <PackageReference Include="NetVips" Version="2.4.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
-    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.14.1" />
-    <PackageReference Include="PhotoSauce.NativeCodecs.Libjpeg" Version="3.0.2-preview1" />
-    <PackageReference Include="SkiaSharp" Version="2.88.6" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.3" /> <!-- 6+ has no improvements and disables Linux support -->
+    <PackageReference Include="Imageflow.AllPlatforms" Version="0.15.1" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.13.1" />
+    <PackageReference Include="NetVips" Version="3.2.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="[3.1.12]" /> <!-- 4+ requires a license file -->
+    <PackageReference Include="PhotoSauce.MagicScaler" Version="0.15.0" />
+    <PackageReference Include="PhotoSauce.NativeCodecs.Libjpeg" Version="3.0.4-preview1" />
+    <PackageReference Include="SkiaSharp" Version="3.119.2" />
+    <PackageReference Include="System.Drawing.Common" Version="[5.0.3]" /> <!-- 6+ has no improvements and disables Linux support -->
   </ItemGroup>
 
   <ItemGroup Condition="'$(BenchmarkWithNuGetBinaries)' == 'true'">
-    <PackageReference Include="NetVips.Native" Version="8.15.0" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="NetVips.Native" Version="8.18.2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -36,6 +36,9 @@ namespace ImageProcessing
 
             // Disable libvips operations cache
             Cache.Max = 0;
+
+            // Reduce concurrency in libvips, as a large thread pool can slow down overall processing
+            NetVips.NetVips.Concurrency = 4;
         }
 
         [Benchmark(Baseline = true, Description = "System.Drawing Resize")]

--- a/NetCore/Resize.cs
+++ b/NetCore/Resize.cs
@@ -137,7 +137,7 @@ namespace ImageProcessing
         public SKSize SkiaBitmapResizeBenchmark()
         {
             using (var original = new SKBitmap(Width, Height))
-            using (var resized = original.Resize(new SKImageInfo(ResizedWidth, ResizedHeight), SKFilterQuality.High))
+            using (var resized = original.Resize(new SKImageInfo(ResizedWidth, ResizedHeight), new SKSamplingOptions(SKCubicResampler.Mitchell)))
             using (var image = SKImage.FromBitmap(resized))
             {
                 return new SKSize(image.Width, image.Height);


### PR DESCRIPTION
Similar to PR #30, this PR updates the dependencies to their latest versions and includes a few other minor improvements. See the individual commits for more details.

<details>
  <summary>Benchmark results on Linux</summary>

```

BenchmarkDotNet v0.15.8, Linux Fedora Linux 44 (Workstation Edition)
AMD Ryzen 9 7900 3.01GHz, 1 CPU, 24 logical and 12 physical cores
.NET SDK 10.0.107
  [Host]   : .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v4
  ShortRun : .NET 10.0.7 (10.0.7, 10.0.726.21808), X64 RyuJIT x86-64-v4

Job=ShortRun  IterationCount=5  LaunchCount=1  
WarmupCount=5  

```

```
| Method                              | Mean      | Error    | StdDev   | Ratio | Allocated  | Alloc Ratio |
|------------------------------------ |----------:|---------:|---------:|------:|-----------:|------------:|
| 'System.Drawing Load, Resize, Save' | 137.70 ms | 6.936 ms | 1.073 ms |  1.00 |   11.71 KB |        1.00 |
| 'ImageFlow Load, Resize, Save'      | 139.10 ms | 1.035 ms | 0.269 ms |  1.01 |  3660.6 KB |      312.58 |
| 'ImageSharp Load, Resize, Save'     |  68.38 ms | 0.444 ms | 0.069 ms |  0.50 | 1286.63 KB |      109.87 |
| 'ImageSharp TD Load, Resize, Save'  |  43.18 ms | 0.069 ms | 0.011 ms |  0.31 | 1283.09 KB |      109.56 |
| 'ImageMagick Load, Resize, Save'    | 228.86 ms | 1.452 ms | 0.377 ms |  1.66 |   54.65 KB |        4.67 |
| 'ImageFree Load, Resize, Save'      | 122.53 ms | 0.115 ms | 0.030 ms |  0.89 |  100.09 KB |        8.55 |
| 'MagicScaler Load, Resize, Save'    |  32.23 ms | 0.117 ms | 0.018 ms |  0.23 |   43.21 KB |        3.69 |
| 'SkiaSharp Load, Resize, Save'      |  81.74 ms | 0.149 ms | 0.023 ms |  0.59 |   68.42 KB |        5.84 |
| 'NetVips Load, Resize, Save'        |  52.17 ms | 1.666 ms | 0.433 ms |  0.38 |   48.78 KB |        4.17 |
```

</details>

<details>
  <summary>Benchmark results on Windows</summary>

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8457/25H2/2025Update/HudsonValley2)
AMD Ryzen 9 7900 3.70GHz, 1 CPU, 24 logical and 12 physical cores
.NET SDK 10.0.300
  [Host]   : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v4
  ShortRun : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v4

Job=ShortRun  IterationCount=5  LaunchCount=1
WarmupCount=5

```

```
| Method                              | Mean      | Error    | StdDev   | Ratio | Allocated  | Alloc Ratio |
|------------------------------------ |----------:|---------:|---------:|------:|-----------:|------------:|
| 'System.Drawing Load, Resize, Save' | 180.74 ms | 7.399 ms | 1.922 ms |  1.00 |    11.9 KB |        1.00 |
| 'ImageFlow Load, Resize, Save'      | 142.50 ms | 2.572 ms | 0.668 ms |  0.79 | 3664.21 KB |      307.96 |
| 'ImageSharp Load, Resize, Save'     |  71.32 ms | 0.999 ms | 0.260 ms |  0.39 | 1289.08 KB |      108.34 |
| 'ImageSharp TD Load, Resize, Save'  |  43.79 ms | 0.540 ms | 0.084 ms |  0.24 |  1283.2 KB |      107.85 |
| 'ImageMagick Load, Resize, Save'    | 247.38 ms | 2.241 ms | 0.582 ms |  1.37 |   54.83 KB |        4.61 |
| 'ImageFree Load, Resize, Save'      | 170.83 ms | 1.142 ms | 0.297 ms |  0.95 |   99.15 KB |        8.33 |
| 'MagicScaler Load, Resize, Save'    |  33.92 ms | 0.054 ms | 0.014 ms |  0.19 |   43.61 KB |        3.66 |
| 'SkiaSharp Load, Resize, Save'      |  86.29 ms | 0.767 ms | 0.119 ms |  0.48 |   68.79 KB |        5.78 |
| 'NetVips Load, Resize, Save'        |  63.43 ms | 1.219 ms | 0.317 ms |  0.35 |   49.14 KB |        4.13 |
```
</details>

<details>
  <summary>Benchmark results on Windows ARM64 (Raspberry Pi 4B w/ 4GB ram)</summary>

```

BenchmarkDotNet v0.15.8, Windows 10 (10.0.19045.7291/22H2/2022Update)
BCM2711 (ARM Cortex-A72) 1.50GHz, 1 CPU, 4 logical and 4 physical cores
.NET SDK 10.0.300
  [Host]   : .NET 10.0.8 (10.0.8, 10.0.826.23019), Arm64 RyuJIT armv8.0-a
  ShortRun : .NET 10.0.8 (10.0.8, 10.0.826.23019), Arm64 RyuJIT armv8.0-a

Job=ShortRun  IterationCount=5  LaunchCount=1
WarmupCount=5

```

```
| Method                              | Mean       | Error     | StdDev   | Ratio | Allocated  | Alloc Ratio |
|------------------------------------ |-----------:|----------:|---------:|------:|-----------:|------------:|
| 'System.Drawing Load, Resize, Save' | 1,302.6 ms | 103.51 ms | 16.02 ms |  1.00 |   11.24 KB |        1.00 |
| 'ImageSharp Load, Resize, Save'     | 1,187.9 ms |  24.39 ms |  3.77 ms |  0.91 |  1385.6 KB |      123.25 |
| 'ImageSharp TD Load, Resize, Save'  |   526.5 ms | 353.11 ms | 91.70 ms |  0.40 | 1382.14 KB |      122.94 |
| 'ImageMagick Load, Resize, Save'    | 2,751.6 ms |  14.57 ms |  2.25 ms |  2.11 |   54.09 KB |        4.81 |
| 'MagicScaler Load, Resize, Save'    |   299.3 ms |  48.81 ms |  7.55 ms |  0.23 |    50.7 KB |        4.51 |
| 'SkiaSharp Load, Resize, Save'      |   567.8 ms |  30.45 ms |  7.91 ms |  0.44 |   58.93 KB |        5.24 |
| 'NetVips Load, Resize, Save'        |   552.1 ms |  36.67 ms |  5.67 ms |  0.42 |   48.38 KB |        4.30 |
```
</details>